### PR TITLE
Fix: Corrige el número de argumentos en la llamada a sp_get_all_forma…

### DIFF
--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -133,8 +133,8 @@ class MatriculaController {
         $profesores = $stmt_profesores->fetchAll(PDO::FETCH_ASSOC);
         $stmt_profesores->closeCursor();
 
-        $stmt_formas_pago = $db->prepare("CALL sp_get_all_formas_pago()");
-        $stmt_formas_pago->execute();
+        $stmt_formas_pago = $db->prepare("CALL sp_get_all_formas_pago(?)");
+        $stmt_formas_pago->execute(['']);
         $formas_pago = $stmt_formas_pago->fetchAll(PDO::FETCH_ASSOC);
         $stmt_formas_pago->closeCursor();
 


### PR DESCRIPTION
…s_pago

Se actualizó la llamada al procedimiento almacenado `sp_get_all_formas_pago` en `MatriculaController` para que pase un parámetro de búsqueda, tal como se requiere en su definición más reciente.

Esto soluciona una `PDOException` que ocurría al intentar crear una nueva matrícula debido a que se llamaba al procedimiento con 0 argumentos cuando esperaba 1. El cambio alinea esta llamada con las de otros controladores que ya utilizan el parámetro de búsqueda.