### PR TITLE
feat: Mostrar fechas de inicio y fin del curso en matrículas y dashboard

### DIFF
--- a/db/sp_get_all_available_schedules.sql
+++ b/db/sp_get_all_available_schedules.sql
@@ -5,6 +5,7 @@ BEGIN
     SELECT
         h.id_horario,
         c.nombre AS curso_nombre,
+        (SELECT pc.fecha_inicio FROM precios_cursos pc WHERE pc.id_curso = h.id_curso AND CURDATE() BETWEEN pc.fecha_inicio AND pc.fecha_fin ORDER BY pc.id_tipo_precio DESC LIMIT 1) AS fecha_inicio_curso,
         (SELECT pc.fecha_fin FROM precios_cursos pc WHERE pc.id_curso = h.id_curso AND CURDATE() BETWEEN pc.fecha_inicio AND pc.fecha_fin ORDER BY pc.id_tipo_precio DESC LIMIT 1) AS fecha_fin_curso,
         CONCAT(p.nombres, ' ', p.apellidos) AS profesor_nombre,
         pi.nombre as piscina_nombre,

--- a/db/update_v4_more_filters.sql
+++ b/db/update_v4_more_filters.sql
@@ -111,7 +111,9 @@ BEGIN
         m.precio_final,
         m.estado,
         u.nombre as admin_nombre,
-        m.fecha_matricula
+        m.fecha_matricula,
+        (SELECT pc.fecha_inicio FROM precios_cursos pc WHERE pc.id_curso = c.id_curso AND m.fecha_matricula BETWEEN pc.fecha_inicio AND pc.fecha_fin ORDER BY pc.id_tipo_precio DESC LIMIT 1) AS fecha_inicio_curso,
+        (SELECT pc.fecha_fin FROM precios_cursos pc WHERE pc.id_curso = c.id_curso AND m.fecha_matricula BETWEEN pc.fecha_inicio AND pc.fecha_fin ORDER BY pc.id_tipo_precio DESC LIMIT 1) AS fecha_fin_curso
     FROM matriculas m
     JOIN alumnos a ON m.id_alumno = a.id_alumno
     JOIN horarios h ON m.id_horario = h.id_horario

--- a/src/views/dashboard.php
+++ b/src/views/dashboard.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/partials/header.php';
                     </div>
                     <div class="card-body">
                         <p><strong>Profesor:</strong> <?php echo htmlspecialchars($schedule['profesor_nombre']); ?></p>
+                        <p><strong>Periodo:</strong> <?php echo ($schedule['fecha_inicio_curso'] && $schedule['fecha_fin_curso']) ? htmlspecialchars(date('d/m/Y', strtotime($schedule['fecha_inicio_curso']))) . ' - ' . htmlspecialchars(date('d/m/Y', strtotime($schedule['fecha_fin_curso']))) : 'No definido'; ?></p>
                         <p><strong>Horario:</strong> <?php echo htmlspecialchars($schedule['tipo_horario_nombre']); ?> (<?php echo htmlspecialchars($schedule['hora_inicio'] . ' - ' . $schedule['hora_fin']); ?>)</p>
                         <p><strong>Ubicación:</strong> Piscina <?php echo htmlspecialchars($schedule['piscina_nombre']); ?>, Carril <?php echo htmlspecialchars($schedule['numero_carril']); ?></p>
                     </div>

--- a/src/views/matriculas/index.php
+++ b/src/views/matriculas/index.php
@@ -50,8 +50,10 @@ require_once __DIR__ . '/../partials/header.php';
                 <th>ID</th>
                 <th>Alumno</th>
                 <th>Curso</th>
-                <th>Fecha Inicio</th>
-                <th>Fecha Fin</th>
+                <th>Inicio Matrícula</th>
+                <th>Fin Matrícula</th>
+                <th>Inicio Curso</th>
+                <th>Fin Curso</th>
                 <th>Precio</th>
                 <th>Estado</th>
                 <th>Acciones</th>
@@ -60,7 +62,7 @@ require_once __DIR__ . '/../partials/header.php';
         <tbody>
             <?php if (empty($matriculas)): ?>
                 <tr>
-                    <td colspan="8">No hay matrículas registradas.</td>
+                    <td colspan="10">No hay matrículas registradas.</td>
                 </tr>
             <?php else: ?>
                 <?php foreach ($matriculas as $matricula): ?>
@@ -70,6 +72,8 @@ require_once __DIR__ . '/../partials/header.php';
                         <td><?php echo htmlspecialchars($matricula['curso_nombre']); ?></td>
                         <td><?php echo htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_inicio']))); ?></td>
                         <td><?php echo htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_fin']))); ?></td>
+                        <td><?php echo $matricula['fecha_inicio_curso'] ? htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_inicio_curso']))) : 'N/A'; ?></td>
+                        <td><?php echo $matricula['fecha_fin_curso'] ? htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_fin_curso']))) : 'N/A'; ?></td>
                         <td>S/ <?php echo htmlspecialchars(number_format($matricula['precio_final'], 2)); ?></td>
                         <td>
                             <span class="status-<?php echo strtolower($matricula['estado']); ?>">


### PR DESCRIPTION
Se ha actualizado la aplicación para mostrar las fechas de inicio y fin de los cursos en dos áreas clave:

1.  **Página de Matrículas (`/matriculas`):**
    - Se modificó el SP `sp_get_all_matriculas_details` para obtener las fechas de inicio y fin del curso (`precios_cursos`) además de las fechas específicas de la matrícula.
    - Se actualizaron las cabeceras de la tabla en la vista para diferenciar entre "Inicio/Fin Matrícula" y "Inicio/Fin Curso".
    - Se añadieron las nuevas columnas a la tabla para mostrar las fechas del curso.

2.  **Dashboard (`/dashboard`):**
    - Se modificó el SP `sp_get_all_horarios_disponibles` para obtener las fechas de inicio y fin del curso.
    - Se actualizó la vista del dashboard para mostrar este rango de fechas (Periodo) en cada tarjeta de horario disponible.

Estos cambios proporcionan a los administradores una visión más clara de los periodos de validez de los cursos al gestionar matrículas y ver horarios disponibles.