### PR TITLE
Fix 404 error when deleting a matricula

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -255,6 +255,7 @@ switch ($route) {
             case 'getHorariosByCurso': $matriculaController->getHorariosByCurso(); break;
             case 'updateDiaClase': $matriculaController->updateDiaClase(); break;
             case 'addRecuperacion': $matriculaController->addRecuperacion(); break;
+            case 'delete': $matriculaController->delete(); break;
             default: http_response_code(404); echo "<h1>404 - Acción no encontrada en Matrículas</h1>"; break;
         }
         break;


### PR DESCRIPTION
The application was throwing a "404 - Action not found in Matrículas" error when the user tried to delete a matricula.

This was caused by a missing 'delete' case in the router for the 'matriculas' controller in `public/index.php`.

This commit adds the missing route, allowing the application to correctly call the `delete()` method in `MatriculaController` and handle the deletion request.