### PR TITLE
Fix period display for available schedules

### DIFF
--- a/db/stored_procedures.sql
+++ b/db/stored_procedures.sql
@@ -698,6 +698,7 @@ BEGIN
         h.id_horario,
         c.nombre AS curso_nombre,
         (SELECT pc.precio FROM precios_cursos pc WHERE pc.id_curso = h.id_curso AND CURDATE() BETWEEN pc.fecha_inicio AND pc.fecha_fin ORDER BY pc.id_tipo_precio DESC LIMIT 1) AS precio_actual,
+        (SELECT pc.fecha_inicio FROM precios_cursos pc WHERE pc.id_curso = h.id_curso AND CURDATE() BETWEEN pc.fecha_inicio AND pc.fecha_fin ORDER BY pc.id_tipo_precio DESC LIMIT 1) AS fecha_inicio_curso,
         (SELECT pc.fecha_fin FROM precios_cursos pc WHERE pc.id_curso = h.id_curso AND CURDATE() BETWEEN pc.fecha_inicio AND pc.fecha_fin ORDER BY pc.id_tipo_precio DESC LIMIT 1) AS fecha_fin_curso,
         CONCAT(p.nombres, ' ', p.apellidos) AS profesor_nombre,
         CONCAT(pi.nombre, ' - Carril ', ca.numero_carril) as carril_nombre,


### PR DESCRIPTION
When creating a new enrollment, the period for available schedules was displayed as "No definida - No definida".

This was because the stored procedure `sp_get_horarios_disponibles_por_curso` was not selecting the `fecha_inicio_curso`.

This commit modifies the stored procedure to include the `fecha_inicio_curso` in the result set, allowing the frontend to display the correct period.