### PR TITLE
Enhance the "Change Schedule" page for enrollments

### DIFF
--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -59,6 +59,19 @@ class MatriculaController {
             $curso_id = $curso_id_result['id_curso'];
             $stmt_curso_id->closeCursor();
 
+            // Obtener el período (fecha_inicio y fecha_fin) del curso actual
+            $stmt_periodo = $db->prepare("SELECT fecha_inicio, fecha_fin FROM precios_cursos WHERE id_curso = ? AND CURDATE() BETWEEN fecha_inicio AND fecha_fin ORDER BY id_tipo_precio DESC LIMIT 1");
+            $stmt_periodo->execute([$curso_id]);
+            $periodo_curso = $stmt_periodo->fetch(PDO::FETCH_ASSOC);
+            $stmt_periodo->closeCursor();
+
+            // Añadir el período a los datos de la matrícula para que esté disponible en la vista
+            if ($periodo_curso) {
+                $matricula['fecha_inicio_curso'] = $periodo_curso['fecha_inicio'];
+                $matricula['fecha_fin_curso'] = $periodo_curso['fecha_fin'];
+            }
+
+
             // Obtener otros horarios disponibles para ese curso
             $stmt_horarios = $db->prepare("CALL sp_get_horarios_disponibles_por_curso(?, ?, ?, ?)");
             $stmt_horarios->execute([$curso_id, 0, null, null]); // Se pasan valores por defecto para los filtros no usados aquí

--- a/src/views/matriculas/edit.php
+++ b/src/views/matriculas/edit.php
@@ -24,6 +24,7 @@ $auth = new AuthController();
         <h4>Información Actual</h4>
         <p><strong>Alumno:</strong> <?php echo htmlspecialchars($matricula['alumno_nombre']); ?></p>
         <p><strong>Curso:</strong> <?php echo htmlspecialchars($matricula['curso_nombre']); ?></p>
+        <p><strong>Periodo del Curso:</strong> <?php echo isset($matricula['fecha_inicio_curso']) ? htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_inicio_curso']))) . ' - ' . htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_fin_curso']))) : 'No definido'; ?></p>
         <p><strong>Horario Actual:</strong> <?php echo htmlspecialchars($matricula['tipo_horario_nombre']); ?> de <?php echo htmlspecialchars(date('h:i A', strtotime($matricula['hora_inicio']))) . ' a ' . htmlspecialchars(date('h:i A', strtotime($matricula['hora_fin']))); ?> (Prof. <?php echo htmlspecialchars($matricula['profesor_nombre']); ?>)</p>
     </div>
 
@@ -52,7 +53,8 @@ $auth = new AuthController();
                 <p>No hay otros horarios con vacantes disponibles para este curso.</p>
             <?php else: ?>
                 <?php foreach ($horarios_disponibles as $horario): ?>
-                    <div class="horario-item" data-id="<?php echo $horario['id_horario']; ?>">
+                    <div class="horario-item" data-id="<?php echo $horario['id_horario']; ?>" data-fecha-fin="<?php echo htmlspecialchars($horario['fecha_fin']); ?>">
+                        <strong>Periodo:</strong> <?php echo htmlspecialchars(date('d/m/Y', strtotime($horario['fecha_inicio']))) . ' - ' . htmlspecialchars(date('d/m/Y', strtotime($horario['fecha_fin']))); ?><br>
                         <strong>Profesor:</strong> <?php echo htmlspecialchars($horario['profesor_nombre']); ?><br>
                         <strong>Lugar:</strong> <?php echo htmlspecialchars($horario['carril_nombre']); ?><br>
                         <strong>Días:</strong> <?php echo htmlspecialchars($horario['tipo_horario_nombre']); ?><br>
@@ -65,26 +67,44 @@ $auth = new AuthController();
 
         <div class="form-actions">
             <a href="index.php?url=matriculas" class="btn btn-secondary">Cancelar</a>
-            <button type="submit" class="btn btn-success" <?php echo empty($horarios_disponibles) ? 'disabled' : ''; ?>>Confirmar Cambio de Horario</button>
+            <button type="submit" class="btn btn-success">Confirmar Cambio</button>
         </div>
     </form>
 </div>
 
 <script>
-document.querySelectorAll('.horario-item').forEach(item => {
-    item.addEventListener('click', function() {
-        document.querySelectorAll('.horario-item').forEach(el => el.classList.remove('selected'));
-        this.classList.add('selected');
-        document.getElementById('id_horario').value = this.dataset.id;
-    });
-});
+document.addEventListener('DOMContentLoaded', function() {
+    const fechaFinCursoActual = '<?php echo $matricula['fecha_fin_curso'] ?? ''; ?>';
+    const fechaFinInput = document.getElementById('fecha_fin');
 
-document.getElementById('form-change-horario').addEventListener('submit', function(event) {
-    const horarioId = document.getElementById('id_horario').value;
-    if (!horarioId) {
-        alert('Por favor, seleccione un nuevo horario.');
-        event.preventDefault();
+    if (fechaFinCursoActual) {
+        fechaFinInput.max = fechaFinCursoActual;
     }
+
+    document.querySelectorAll('.horario-item').forEach(item => {
+        item.addEventListener('click', function() {
+            document.querySelectorAll('.horario-item').forEach(el => el.classList.remove('selected'));
+            this.classList.add('selected');
+            document.getElementById('id_horario').value = this.dataset.id;
+
+            // Actualizar la restricción de la fecha final
+            const fechaFinNuevoCurso = this.dataset.fechaFin;
+            if (fechaFinNuevoCurso) {
+                fechaFinInput.max = fechaFinNuevoCurso;
+                if (fechaFinInput.value > fechaFinNuevoCurso) {
+                    fechaFinInput.value = fechaFinNuevoCurso;
+                }
+            }
+        });
+    });
+
+    document.getElementById('form-change-horario').addEventListener('submit', function(event) {
+        const horarioId = document.getElementById('id_horario').value;
+        if (!horarioId) {
+            alert('Por favor, seleccione un nuevo horario.');
+            event.preventDefault();
+        }
+    });
 });
 </script>
 


### PR DESCRIPTION
This commit addresses several user requests to improve the "change schedule" functionality for enrollments:

1.  **Display Current Course Period:** The controller now fetches the current course's start and end dates, and the view displays them in the "Current Information" section.
2.  **Display Period for New Schedules:** The list of available new schedules now shows the start and end date for each course period.
3.  **End Date Validation:** JavaScript logic has been added to restrict the "New End Date" input field. The `max` attribute is dynamically set based on the selected course's end date, preventing users from selecting a date beyond the course's validity.

These changes provide more context to the user and improve the validation of the form.