### PR TITLE
fix: Add new report routes to the router

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -279,7 +279,11 @@ switch ($route) {
         switch($action) {
             case 'ventas': $reporteController->ventas(); break;
             case 'profesores': $reporteController->profesores(); break;
-            case 'exportarVentas': $reporteController->exportarVentas(); break; // Ruta añadida
+            case 'exportarVentas': $reporteController->exportarVentas(); break;
+            case 'ventasPorFormaPago': $reporteController->ventasPorFormaPago(); break;
+            case 'ventasPorCurso': $reporteController->ventasPorCurso(); break;
+            case 'ventasPorProfesor': $reporteController->ventasPorProfesor(); break;
+            case 'ventasPorPiscinaCarril': $reporteController->ventasPorPiscinaCarril(); break;
             default: http_response_code(404); echo "<h1>404 - Reporte no encontrado</h1>"; break;
         }
         break;


### PR DESCRIPTION
This commit fixes a 404 error when accessing the new sales reports. The new report routes were missing from the router in `public/index.php`. This commit adds the missing routes to the router's switch statement.