### PR TITLE
fix: Apply correct styling to new reports

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -209,3 +209,34 @@ footer {
 .status-programada { color: #007bff; font-weight: bold; }
 .status-finalizada { color: #6c757d; font-weight: bold; }
 .status-vigente { color: #17a2b8; font-weight: bold; }
+
+/* Report specific styles */
+.filter-container {
+    background-color: #f9f9f9;
+    padding: 1.5rem;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+}
+.filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-end;
+}
+.report-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+.report-table th, .report-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+.report-table th {
+    background-color: #f2f2f2;
+}
+.total-row {
+    font-weight: bold;
+    background-color: #f2f2f2;
+}

--- a/src/views/reportes/ventas.php
+++ b/src/views/reportes/ventas.php
@@ -2,18 +2,6 @@
 require_once __DIR__ . '/../partials/header.php';
 ?>
 
-<style>
-.container { padding: 2rem; }
-.page-header h1 { margin-bottom: 1rem; }
-.filter-container { background-color: #f9f9f9; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
-.filter-form { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; }
-.form-group { display: flex; flex-direction: column; }
-.report-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-.report-table th, .report-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
-.report-table th { background-color: #f2f2f2; }
-.total-row { font-weight: bold; background-color: #f2f2f2; }
-</style>
-
 <div class="container">
     <div class="page-header">
         <h1>Reporte de Ventas</h1>

--- a/src/views/reportes/ventas_por_curso.php
+++ b/src/views/reportes/ventas_por_curso.php
@@ -3,17 +3,20 @@ require_once __DIR__ . '/../partials/header.php';
 ?>
 
 <div class="container">
-    <h1>Reporte de Ventas por Curso</h1>
+    <div class="page-header">
+        <h1>Reporte de Ventas por Curso</h1>
+    </div>
 
     <div class="filter-container">
-        <form action="index.php" method="GET">
+        <h4>Filtros del Reporte</h4>
+        <form class="filter-form" action="index.php" method="GET">
             <input type="hidden" name="url" value="reportes/ventasPorCurso">
             <div class="form-group">
-                <label for="fecha_inicio">Fecha Inicio:</label>
+                <label for="fecha_inicio">Fecha Inicio</label>
                 <input type="date" id="fecha_inicio" name="fecha_inicio" value="<?php echo htmlspecialchars($fecha_inicio); ?>">
             </div>
             <div class="form-group">
-                <label for="fecha_fin">Fecha Fin:</label>
+                <label for="fecha_fin">Fecha Fin</label>
                 <input type="date" id="fecha_fin" name="fecha_fin" value="<?php echo htmlspecialchars($fecha_fin); ?>">
             </div>
             <button type="submit" class="btn btn-primary">Generar Reporte</button>
@@ -36,7 +39,15 @@ require_once __DIR__ . '/../partials/header.php';
                     <td colspan="5">No se encontraron resultados para el período seleccionado.</td>
                 </tr>
             <?php else: ?>
-                <?php foreach ($reporte_data as $row): ?>
+                <?php
+                $total_base = 0;
+                $total_descuentos = 0;
+                $total_ventas = 0;
+                foreach ($reporte_data as $row):
+                    $total_base += $row['total_base'];
+                    $total_descuentos += $row['total_descuentos'];
+                    $total_ventas += $row['total_ventas'];
+                ?>
                     <tr>
                         <td><?php echo htmlspecialchars($row['curso_nombre']); ?></td>
                         <td><?php echo htmlspecialchars($row['cantidad_matriculas']); ?></td>
@@ -47,6 +58,14 @@ require_once __DIR__ . '/../partials/header.php';
                 <?php endforeach; ?>
             <?php endif; ?>
         </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="2" style="text-align: right;"><strong>Totales:</strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_base, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_descuentos, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_ventas, 2)); ?></strong></td>
+            </tr>
+        </tfoot>
     </table>
 </div>
 

--- a/src/views/reportes/ventas_por_forma_pago.php
+++ b/src/views/reportes/ventas_por_forma_pago.php
@@ -3,17 +3,20 @@ require_once __DIR__ . '/../partials/header.php';
 ?>
 
 <div class="container">
-    <h1>Reporte de Ventas por Forma de Pago</h1>
+    <div class="page-header">
+        <h1>Reporte de Ventas por Forma de Pago</h1>
+    </div>
 
     <div class="filter-container">
-        <form action="index.php" method="GET">
+        <h4>Filtros del Reporte</h4>
+        <form class="filter-form" action="index.php" method="GET">
             <input type="hidden" name="url" value="reportes/ventasPorFormaPago">
             <div class="form-group">
-                <label for="fecha_inicio">Fecha Inicio:</label>
+                <label for="fecha_inicio">Fecha Inicio</label>
                 <input type="date" id="fecha_inicio" name="fecha_inicio" value="<?php echo htmlspecialchars($fecha_inicio); ?>">
             </div>
             <div class="form-group">
-                <label for="fecha_fin">Fecha Fin:</label>
+                <label for="fecha_fin">Fecha Fin</label>
                 <input type="date" id="fecha_fin" name="fecha_fin" value="<?php echo htmlspecialchars($fecha_fin); ?>">
             </div>
             <button type="submit" class="btn btn-primary">Generar Reporte</button>
@@ -36,7 +39,15 @@ require_once __DIR__ . '/../partials/header.php';
                     <td colspan="5">No se encontraron resultados para el período seleccionado.</td>
                 </tr>
             <?php else: ?>
-                <?php foreach ($reporte_data as $row): ?>
+                <?php
+                $total_base = 0;
+                $total_descuentos = 0;
+                $total_ventas = 0;
+                foreach ($reporte_data as $row):
+                    $total_base += $row['total_base'];
+                    $total_descuentos += $row['total_descuentos'];
+                    $total_ventas += $row['total_ventas'];
+                ?>
                     <tr>
                         <td><?php echo htmlspecialchars($row['forma_pago_nombre']); ?></td>
                         <td><?php echo htmlspecialchars($row['cantidad_transacciones']); ?></td>
@@ -47,6 +58,14 @@ require_once __DIR__ . '/../partials/header.php';
                 <?php endforeach; ?>
             <?php endif; ?>
         </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="2" style="text-align: right;"><strong>Totales:</strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_base, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_descuentos, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_ventas, 2)); ?></strong></td>
+            </tr>
+        </tfoot>
     </table>
 </div>
 

--- a/src/views/reportes/ventas_por_piscina_carril.php
+++ b/src/views/reportes/ventas_por_piscina_carril.php
@@ -3,17 +3,20 @@ require_once __DIR__ . '/../partials/header.php';
 ?>
 
 <div class="container">
-    <h1>Reporte de Ventas por Piscina y Carril</h1>
+    <div class="page-header">
+        <h1>Reporte de Ventas por Piscina y Carril</h1>
+    </div>
 
     <div class="filter-container">
-        <form action="index.php" method="GET">
+        <h4>Filtros del Reporte</h4>
+        <form class="filter-form" action="index.php" method="GET">
             <input type="hidden" name="url" value="reportes/ventasPorPiscinaCarril">
             <div class="form-group">
-                <label for="fecha_inicio">Fecha Inicio:</label>
+                <label for="fecha_inicio">Fecha Inicio</label>
                 <input type="date" id="fecha_inicio" name="fecha_inicio" value="<?php echo htmlspecialchars($fecha_inicio); ?>">
             </div>
             <div class="form-group">
-                <label for="fecha_fin">Fecha Fin:</label>
+                <label for="fecha_fin">Fecha Fin</label>
                 <input type="date" id="fecha_fin" name="fecha_fin" value="<?php echo htmlspecialchars($fecha_fin); ?>">
             </div>
             <button type="submit" class="btn btn-primary">Generar Reporte</button>
@@ -37,7 +40,15 @@ require_once __DIR__ . '/../partials/header.php';
                     <td colspan="6">No se encontraron resultados para el período seleccionado.</td>
                 </tr>
             <?php else: ?>
-                <?php foreach ($reporte_data as $row): ?>
+                <?php
+                $total_base = 0;
+                $total_descuentos = 0;
+                $total_ventas = 0;
+                foreach ($reporte_data as $row):
+                    $total_base += $row['total_base'];
+                    $total_descuentos += $row['total_descuentos'];
+                    $total_ventas += $row['total_ventas'];
+                ?>
                     <tr>
                         <td><?php echo htmlspecialchars($row['piscina_nombre']); ?></td>
                         <td><?php echo htmlspecialchars($row['numero_carril']); ?></td>
@@ -49,6 +60,14 @@ require_once __DIR__ . '/../partials/header.php';
                 <?php endforeach; ?>
             <?php endif; ?>
         </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="3" style="text-align: right;"><strong>Totales:</strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_base, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_descuentos, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_ventas, 2)); ?></strong></td>
+            </tr>
+        </tfoot>
     </table>
 </div>
 

--- a/src/views/reportes/ventas_por_profesor.php
+++ b/src/views/reportes/ventas_por_profesor.php
@@ -3,17 +3,20 @@ require_once __DIR__ . '/../partials/header.php';
 ?>
 
 <div class="container">
-    <h1>Reporte de Ventas por Profesor</h1>
+    <div class="page-header">
+        <h1>Reporte de Ventas por Profesor</h1>
+    </div>
 
     <div class="filter-container">
-        <form action="index.php" method="GET">
+        <h4>Filtros del Reporte</h4>
+        <form class="filter-form" action="index.php" method="GET">
             <input type="hidden" name="url" value="reportes/ventasPorProfesor">
             <div class="form-group">
-                <label for="fecha_inicio">Fecha Inicio:</label>
+                <label for="fecha_inicio">Fecha Inicio</label>
                 <input type="date" id="fecha_inicio" name="fecha_inicio" value="<?php echo htmlspecialchars($fecha_inicio); ?>">
             </div>
             <div class="form-group">
-                <label for="fecha_fin">Fecha Fin:</label>
+                <label for="fecha_fin">Fecha Fin</label>
                 <input type="date" id="fecha_fin" name="fecha_fin" value="<?php echo htmlspecialchars($fecha_fin); ?>">
             </div>
             <button type="submit" class="btn btn-primary">Generar Reporte</button>
@@ -36,7 +39,15 @@ require_once __DIR__ . '/../partials/header.php';
                     <td colspan="5">No se encontraron resultados para el período seleccionado.</td>
                 </tr>
             <?php else: ?>
-                <?php foreach ($reporte_data as $row): ?>
+                <?php
+                $total_base = 0;
+                $total_descuentos = 0;
+                $total_ventas = 0;
+                foreach ($reporte_data as $row):
+                    $total_base += $row['total_base'];
+                    $total_descuentos += $row['total_descuentos'];
+                    $total_ventas += $row['total_ventas'];
+                ?>
                     <tr>
                         <td><?php echo htmlspecialchars($row['profesor_nombre']); ?></td>
                         <td><?php echo htmlspecialchars($row['cantidad_matriculas']); ?></td>
@@ -47,6 +58,14 @@ require_once __DIR__ . '/../partials/header.php';
                 <?php endforeach; ?>
             <?php endif; ?>
         </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="2" style="text-align: right;"><strong>Totales:</strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_base, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_descuentos, 2)); ?></strong></td>
+                <td><strong>S/ <?php echo htmlspecialchars(number_format($total_ventas, 2)); ?></strong></td>
+            </tr>
+        </tfoot>
     </table>
 </div>
 


### PR DESCRIPTION
This commit fixes the styling of the new sales reports to match the existing reports.

- Report-specific styles have been moved from an inline style block in `ventas.php` to the central `style.css` file.
- All report views (new and old) now use the centralized styles.
- The new report views have been updated to use the correct CSS classes.
- Fixed the totals calculation in the footer of the new reports.