### PR TITLE
fix: Align new report styles with existing reports

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -209,34 +209,3 @@ footer {
 .status-programada { color: #007bff; font-weight: bold; }
 .status-finalizada { color: #6c757d; font-weight: bold; }
 .status-vigente { color: #17a2b8; font-weight: bold; }
-
-/* Report specific styles */
-.filter-container {
-    background-color: #f9f9f9;
-    padding: 1.5rem;
-    border-radius: 8px;
-    margin-bottom: 2rem;
-}
-.filter-form {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    align-items: flex-end;
-}
-.report-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 1rem;
-}
-.report-table th, .report-table td {
-    border: 1px solid #ddd;
-    padding: 8px;
-    text-align: left;
-}
-.report-table th {
-    background-color: #f2f2f2;
-}
-.total-row {
-    font-weight: bold;
-    background-color: #f2f2f2;
-}

--- a/src/views/reportes/ventas.php
+++ b/src/views/reportes/ventas.php
@@ -2,6 +2,18 @@
 require_once __DIR__ . '/../partials/header.php';
 ?>
 
+<style>
+.container { padding: 2rem; }
+.page-header h1 { margin-bottom: 1rem; }
+.filter-container { background-color: #f9f9f9; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
+.filter-form { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; }
+.form-group { display: flex; flex-direction: column; }
+.report-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+.report-table th, .report-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+.report-table th { background-color: #f2f2f2; }
+.total-row { font-weight: bold; background-color: #f2f2f2; }
+</style>
+
 <div class="container">
     <div class="page-header">
         <h1>Reporte de Ventas</h1>

--- a/src/views/reportes/ventas_por_curso.php
+++ b/src/views/reportes/ventas_por_curso.php
@@ -2,6 +2,18 @@
 require_once __DIR__ . '/../partials/header.php';
 ?>
 
+<style>
+.container { padding: 2rem; }
+.page-header h1 { margin-bottom: 1rem; }
+.filter-container { background-color: #f9f9f9; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
+.filter-form { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; }
+.form-group { display: flex; flex-direction: column; }
+.report-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+.report-table th, .report-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+.report-table th { background-color: #f2f2f2; }
+.total-row { font-weight: bold; background-color: #f2f2f2; }
+</style>
+
 <div class="container">
     <div class="page-header">
         <h1>Reporte de Ventas por Curso</h1>

--- a/src/views/reportes/ventas_por_forma_pago.php
+++ b/src/views/reportes/ventas_por_forma_pago.php
@@ -2,6 +2,18 @@
 require_once __DIR__ . '/../partials/header.php';
 ?>
 
+<style>
+.container { padding: 2rem; }
+.page-header h1 { margin-bottom: 1rem; }
+.filter-container { background-color: #f9f9f9; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
+.filter-form { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; }
+.form-group { display: flex; flex-direction: column; }
+.report-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+.report-table th, .report-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+.report-table th { background-color: #f2f2f2; }
+.total-row { font-weight: bold; background-color: #f2f2f2; }
+</style>
+
 <div class="container">
     <div class="page-header">
         <h1>Reporte de Ventas por Forma de Pago</h1>

--- a/src/views/reportes/ventas_por_piscina_carril.php
+++ b/src/views/reportes/ventas_por_piscina_carril.php
@@ -2,6 +2,18 @@
 require_once __DIR__ . '/../partials/header.php';
 ?>
 
+<style>
+.container { padding: 2rem; }
+.page-header h1 { margin-bottom: 1rem; }
+.filter-container { background-color: #f9f9f9; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
+.filter-form { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; }
+.form-group { display: flex; flex-direction: column; }
+.report-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+.report-table th, .report-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+.report-table th { background-color: #f2f2f2; }
+.total-row { font-weight: bold; background-color: #f2f2f2; }
+</style>
+
 <div class="container">
     <div class="page-header">
         <h1>Reporte de Ventas por Piscina y Carril</h1>

--- a/src/views/reportes/ventas_por_profesor.php
+++ b/src/views/reportes/ventas_por_profesor.php
@@ -2,6 +2,18 @@
 require_once __DIR__ . '/../partials/header.php';
 ?>
 
+<style>
+.container { padding: 2rem; }
+.page-header h1 { margin-bottom: 1rem; }
+.filter-container { background-color: #f9f9f9; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
+.filter-form { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; }
+.form-group { display: flex; flex-direction: column; }
+.report-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+.report-table th, .report-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+.report-table th { background-color: #f2f2f2; }
+.total-row { font-weight: bold; background-color: #f2f2f2; }
+</style>
+
 <div class="container">
     <div class="page-header">
         <h1>Reporte de Ventas por Profesor</h1>


### PR DESCRIPTION
This commit corrects the styling of the new sales reports to match the format of the existing `profesores.php` report, as requested by the user.

- The previous change to centralize styles has been reverted.
- The `ventas.php` report and the main `style.css` have been restored to their original state.
- An inline style block, identical to the one in `profesores.php`, has been added to each of the four new report views to ensure a consistent look and feel.