### PR TITLE
fix: Update student attendance button and badge colors

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -141,7 +141,29 @@ footer {
 .btn-info { background-color: #17a2b8; }
 .btn-warning { background-color: #ffc107; color: #212529; }
 .btn-danger { background-color: #dc3545; }
+.btn-success { background-color: #28a745; }
 .btn-disabled { background-color: #ccc; cursor: not-allowed; opacity: 0.6; }
+
+
+/* Badges */
+.badge {
+    display: inline-block;
+    padding: 0.35em 0.65em;
+    font-size: .75em;
+    font-weight: 700;
+    line-height: 1;
+    color: #fff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 0.25rem;
+}
+
+.badge-primary { background-color: #0056b3; }
+.badge-secondary { background-color: #6c757d; }
+.badge-info { background-color: #17a2b8; }
+.badge-warning { background-color: #ffc107; color: #212529; }
+.badge-danger { background-color: #dc3545; }
 
 
 /* Tables */

--- a/src/views/asistencias_alumnos/show.php
+++ b/src/views/asistencias_alumnos/show.php
@@ -34,12 +34,22 @@ require_once __DIR__ . '/../partials/header.php';
             <tr id="row-<?php echo $fecha; ?>">
                 <td><?php echo date('d/m/Y', strtotime($fecha)); ?> (<?php echo ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'][date('w', strtotime($fecha))]; ?>)</td>
                 <td class="status-cell">
-                    <span class="badge badge-<?php echo strtolower(str_replace('_', '-', $data['estado'])); ?>">
+                    <?php
+                    $estado_class = 'secondary'; // Default for 'no_marcado'
+                    if ($data['estado'] === 'asistio') {
+                        $estado_class = 'primary';
+                    } elseif ($data['estado'] === 'falto') {
+                        $estado_class = 'warning';
+                    } elseif ($data['estado'] === 'postergado') {
+                        $estado_class = 'info';
+                    }
+                    ?>
+                    <span class="badge badge-<?php echo $estado_class; ?>">
                         <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $data['estado']))); ?>
                     </span>
                 </td>
                 <td class="actions-cell">
-                    <button class="btn btn-success btn-sm" onclick="marcarAsistencia('<?php echo $fecha; ?>', 'asistio')">Asistió</button>
+                    <button class="btn btn-primary btn-sm" onclick="marcarAsistencia('<?php echo $fecha; ?>', 'asistio')">Asistió</button>
                     <button class="btn btn-warning btn-sm" onclick="marcarAsistencia('<?php echo $fecha; ?>', 'falto')">Faltó</button>
                     <button class="btn btn-info btn-sm" onclick="marcarAsistencia('<?php echo $fecha; ?>', 'postergado')">Postergado</button>
                 </td>


### PR DESCRIPTION
This commit addresses a user request to improve the visibility of the 'Asistió' button on the student attendance page.

- Changes the 'Asistió' button class to `btn-primary` to make it blue.
- Updates the logic in the view to use standard Bootstrap badge classes for attendance statuses (`primary`, `warning`, `info`, `secondary`).
- Adds custom CSS to `style.css` to define styles for badges and the `.btn-success` class to ensure consistent colors across the application.