### PR TITLE
refactor: Unify student attendance data source

### DIFF
--- a/db/IT-2025-08-27-fix-student-attendance-sync.sql
+++ b/db/IT-2025-08-27-fix-student-attendance-sync.sql
@@ -1,0 +1,15 @@
+-- Este script corrige la inconsistencia de datos de asistencia de alumnos
+-- eliminando la tabla y el procedimiento almacenado redundantes que se crearon
+-- para la nueva página de "Asistencia Alumno".
+-- La funcionalidad ahora utilizará la tabla `matricula_dias` y el SP `sp_update_asistencia_alumno`
+-- que ya existían y eran utilizados por la página de "Detalles de la Matrícula".
+
+-- 1. Eliminar la tabla de asistencias de alumnos redundante
+DROP TABLE IF EXISTS `asistencias_alumnos`;
+
+-- 2. Eliminar el procedimiento almacenado redundante
+DROP PROCEDURE IF EXISTS `sp_create_or_update_asistencia_alumno`;
+
+-- NOTA: El procedimiento `sp_listar_matriculas_alumno_filtrado` se conserva
+-- porque es utilizado por la página de índice de asistencia de alumnos para
+-- listar las matrículas, y no depende de la tabla eliminada.

--- a/src/controllers/AsistenciaAlumnoController.php
+++ b/src/controllers/AsistenciaAlumnoController.php
@@ -84,39 +84,11 @@ class AsistenciaAlumnoController {
                 throw new Exception("Matrícula no encontrada.");
             }
 
-            // 2. Generar las fechas de clase esperadas
-            $dias_semana_num = explode(',', $matricula['dias_semana']);
-            $fecha_actual = new DateTime($matricula['fecha_inicio']);
-            $fecha_fin = new DateTime($matricula['fecha_fin']);
-
-            while ($fecha_actual <= $fecha_fin) {
-                $dayOfWeek = (int)$fecha_actual->format('w') + 1;
-                if (in_array($dayOfWeek, $dias_semana_num)) {
-                    $dias_clase[$fecha_actual->format('Y-m-d')] = [
-                        'fecha_clase' => $fecha_actual->format('Y-m-d'),
-                        'estado' => 'no_marcado',
-                        'observaciones' => ''
-                    ];
-                }
-                $fecha_actual->modify('+1 day');
-            }
-
-            // 3. Obtener los registros de asistencia que ya existen
-            $stmt_asistencias = $db->prepare("
-                SELECT fecha_clase, estado, observaciones
-                FROM asistencias_alumnos
-                WHERE id_matricula = ?
-            ");
-            $stmt_asistencias->execute([$id_matricula]);
-            $asistencias_guardadas = $stmt_asistencias->fetchAll(PDO::FETCH_ASSOC);
-
-            // 4. Fusionar los estados guardados
-            foreach ($asistencias_guardadas as $asistencia) {
-                if (isset($dias_clase[$asistencia['fecha_clase']])) {
-                    $dias_clase[$asistencia['fecha_clase']]['estado'] = $asistencia['estado'];
-                    $dias_clase[$asistencia['fecha_clase']]['observaciones'] = $asistencia['observaciones'];
-                }
-            }
+            // 2. Obtener los días de clase y sus estados desde `matricula_dias`
+            $stmt_dias = $db->prepare("CALL sp_get_matricula_dias(?)");
+            $stmt_dias->execute([$id_matricula]);
+            $dias_clase = $stmt_dias->fetchAll(PDO::FETCH_ASSOC);
+            $stmt_dias->closeCursor();
 
         } catch (Exception $e) {
             $_SESSION['error_message'] = "Error: " . $e->getMessage();
@@ -128,27 +100,26 @@ class AsistenciaAlumnoController {
     }
 
     /**
-     * Guarda la asistencia de un alumno (vía AJAX).
+     * Guarda la asistencia de un alumno (vía AJAX), reutilizando la lógica de Matrícula.
      */
     public function save() {
         header('Content-Type: application/json');
         $this->auth->verifyCsrfToken();
 
-        $id_matricula = $_POST['id_matricula'] ?? null;
-        $id_alumno = $_POST['id_alumno'] ?? null;
-        $fecha_clase = $_POST['fecha_clase'] ?? null;
+        $id_matricula_dia = $_POST['id_matricula_dia'] ?? null;
         $estado = $_POST['estado'] ?? null;
         $observaciones = $_POST['observaciones'] ?? '';
 
-        if (!$id_matricula || !$id_alumno || !$fecha_clase || !$estado) {
+        if (!$id_matricula_dia || !$estado) {
             echo json_encode(['success' => false, 'message' => 'Datos incompletos.']);
             exit;
         }
 
         $db = Database::getInstance()->getConnection();
         try {
-            $stmt = $db->prepare("CALL sp_create_or_update_asistencia_alumno(?, ?, ?, ?, ?)");
-            $stmt->execute([$id_matricula, $id_alumno, $fecha_clase, $estado, $observaciones]);
+            // Llamar al mismo SP que usa la página de detalles de matrícula para consistencia
+            $stmt = $db->prepare("CALL sp_update_asistencia_alumno(?, ?, ?)");
+            $stmt->execute([$id_matricula_dia, $estado, $observaciones]);
             echo json_encode(['success' => true]);
         } catch (PDOException $e) {
             echo json_encode(['success' => false, 'message' => 'Error al guardar la asistencia: ' . $e->getMessage()]);

--- a/src/views/asistencias_alumnos/show.php
+++ b/src/views/asistencias_alumnos/show.php
@@ -30,31 +30,29 @@ require_once __DIR__ . '/../partials/header.php';
             </tr>
         </thead>
         <tbody>
-            <?php foreach ($dias_clase as $fecha => $data): ?>
-            <tr id="row-<?php echo $fecha; ?>">
-                <td><?php echo date('d/m/Y', strtotime($fecha)); ?> (<?php echo ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'][date('w', strtotime($fecha))]; ?>)</td>
+            <?php foreach ($dias_clase as $dia): ?>
+            <tr id="row-<?php echo $dia['id_matricula_dia']; ?>">
+                <td><?php echo date('d/m/Y', strtotime($dia['fecha_clase'])); ?> (<?php echo ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'][date('w', strtotime($dia['fecha_clase']))]; ?>)</td>
                 <td class="status-cell">
                     <?php
-                    $estado_class = 'secondary'; // Default for 'no_marcado'
-                    if ($data['estado'] === 'asistio') {
-                        $estado_class = 'primary';
-                    } elseif ($data['estado'] === 'falto') {
-                        $estado_class = 'warning';
-                    } elseif ($data['estado'] === 'postergado') {
-                        $estado_class = 'info';
-                    }
+                    $estado_class = 'secondary'; // Default
+                    if ($dia['estado'] === 'asistio') $estado_class = 'primary';
+                    elseif ($dia['estado'] === 'falto') $estado_class = 'warning';
+                    elseif ($dia['estado'] === 'postergada') $estado_class = 'info';
+                    elseif ($dia['estado'] === 'recuperada') $estado_class = 'success';
+                    elseif ($dia['estado'] === 'programada') $estado_class = 'light';
                     ?>
                     <span class="badge badge-<?php echo $estado_class; ?>">
-                        <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $data['estado']))); ?>
+                        <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $dia['estado']))); ?>
                     </span>
                 </td>
                 <td class="actions-cell">
-                    <button class="btn btn-primary btn-sm" onclick="marcarAsistencia('<?php echo $fecha; ?>', 'asistio')">Asistió</button>
-                    <button class="btn btn-warning btn-sm" onclick="marcarAsistencia('<?php echo $fecha; ?>', 'falto')">Faltó</button>
-                    <button class="btn btn-info btn-sm" onclick="marcarAsistencia('<?php echo $fecha; ?>', 'postergado')">Postergado</button>
+                    <button class="btn btn-primary btn-sm" onclick="marcarAsistencia(<?php echo $dia['id_matricula_dia']; ?>, 'asistio')">Asistió</button>
+                    <button class="btn btn-warning btn-sm" onclick="marcarAsistencia(<?php echo $dia['id_matricula_dia']; ?>, 'falto')">Faltó</button>
+                    <button class="btn btn-info btn-sm" onclick="marcarAsistencia(<?php echo $dia['id_matricula_dia']; ?>, 'postergada')">Postergada</button>
                 </td>
                 <td class="obs-cell">
-                    <textarea class="form-control" onchange="guardarObservaciones('<?php echo $fecha; ?>')"><?php echo htmlspecialchars($data['observaciones']); ?></textarea>
+                    <textarea class="form-control" onchange="guardarObservaciones(<?php echo $dia['id_matricula_dia']; ?>)"><?php echo htmlspecialchars($dia['observacion'] ?? ''); ?></textarea>
                 </td>
             </tr>
             <?php endforeach; ?>
@@ -68,28 +66,28 @@ require_once __DIR__ . '/../partials/header.php';
 </div>
 
 <script>
-function marcarAsistencia(fecha, estado) {
-    const observaciones = document.querySelector(`#row-${fecha} textarea`).value;
-    guardarAsistencia(fecha, estado, observaciones);
+function marcarAsistencia(id_dia, estado) {
+    const observaciones = document.querySelector(`#row-${id_dia} textarea`).value;
+    guardarAsistencia(id_dia, estado, observaciones);
 }
 
-function guardarObservaciones(fecha) {
-    const estadoActual = document.querySelector(`#row-${fecha} .status-cell .badge`).textContent.trim().toLowerCase().replace(' ', '_');
-    if (estadoActual !== 'no_marcado') {
-        const observaciones = document.querySelector(`#row-${fecha} textarea`).value;
-        guardarAsistencia(fecha, estadoActual, observaciones);
+function guardarObservaciones(id_dia) {
+    const estadoActualBadge = document.querySelector(`#row-${id_dia} .status-cell .badge`);
+    // Extraer el estado del texto del badge, puede ser "Programada", "Asistio", etc.
+    const estadoActual = estadoActualBadge.textContent.trim().toLowerCase().replace(' ', '_');
+
+    // Solo guardar si ya hay un estado significativo
+    if (estadoActual !== 'programada' && estadoActual !== 'no_marcado') {
+        const observaciones = document.querySelector(`#row-${id_dia} textarea`).value;
+        guardarAsistencia(id_dia, estadoActual, observaciones);
     }
 }
 
-function guardarAsistencia(fecha, estado, observaciones) {
-    const id_matricula = <?php echo $matricula['id_matricula']; ?>;
-    const id_alumno = <?php echo $matricula['id_alumno']; ?>;
+function guardarAsistencia(id_dia, estado, observaciones) {
     const csrf_token = '<?php echo $_SESSION['csrf_token']; ?>';
 
     const formData = new FormData();
-    formData.append('id_matricula', id_matricula);
-    formData.append('id_alumno', id_alumno);
-    formData.append('fecha_clase', fecha);
+    formData.append('id_matricula_dia', id_dia);
     formData.append('estado', estado);
     formData.append('observaciones', observaciones);
     formData.append('csrf_token', csrf_token);
@@ -101,11 +99,17 @@ function guardarAsistencia(fecha, estado, observaciones) {
     .then(response => response.json())
     .then(data => {
         if (data.success) {
-            const statusCell = document.querySelector(`#row-${fecha} .status-cell`);
-            let estadoClass = estado.toLowerCase().replace('_', '-');
-            let estadoText = estado.charAt(0).toUpperCase() + estado.slice(1).replace('_', ' ');
+            // Actualizar la UI dinámicamente
+            const statusCell = document.querySelector(`#row-${id_dia} .status-cell`);
+            let estadoClass = 'secondary';
+            if (estado === 'asistio') estadoClass = 'primary';
+            else if (estado === 'falto') estadoClass = 'warning';
+            else if (estado === 'postergada') estadoClass = 'info';
+            else if (estado === 'recuperada') estadoClass = 'success';
+            else if (estado === 'programada') estadoClass = 'light';
+
+            const estadoText = estado.charAt(0).toUpperCase() + estado.slice(1).replace('_', ' ');
             statusCell.innerHTML = `<span class="badge badge-${estadoClass}">${estadoText}</span>`;
-            // Opcional: mostrar un mensaje de éxito
         } else {
             alert('Error al guardar la asistencia: ' + data.message);
         }


### PR DESCRIPTION
This commit refactors the student attendance feature to ensure data consistency between the new 'Asistencia Alumno' page and the existing 'Detalles de la Matrícula' page.

- Modifies `AsistenciaAlumnoController` to use the `matricula_dias` table as the single source of truth for student attendance, instead of the previously created `asistencias_alumnos` table.
- Updates the controller to use the existing `sp_update_asistencia_alumno` stored procedure for saving attendance data.
- Updates the `asistencias_alumnos/show.php` view to work with the `matricula_dias` table structure and sends the correct `id_matricula_dia` when updating attendance.
- Adds a new SQL script to drop the redundant `asistencias_alumnos` table and its associated stored procedure to clean up the database.