### PR TITLE
fix: Correct number of arguments for sp_get_all_cursos

### DIFF
--- a/src/controllers/PrecioCursoController.php
+++ b/src/controllers/PrecioCursoController.php
@@ -22,8 +22,8 @@ class PrecioCursoController {
 
     public function create() {
         $db = Database::getInstance()->getConnection();
-        $stmt_cursos = $db->prepare("CALL sp_get_all_cursos()");
-        $stmt_cursos->execute();
+        $stmt_cursos = $db->prepare("CALL sp_get_all_cursos(?)");
+        $stmt_cursos->execute(['']);
         $cursos = $stmt_cursos->fetchAll(PDO::FETCH_ASSOC);
         $stmt_cursos->closeCursor();
 
@@ -69,8 +69,8 @@ class PrecioCursoController {
         $stmt_item->closeCursor();
 
         if ($item) {
-            $stmt_cursos = $db->prepare("CALL sp_get_all_cursos()");
-            $stmt_cursos->execute();
+            $stmt_cursos = $db->prepare("CALL sp_get_all_cursos(?)");
+            $stmt_cursos->execute(['']);
             $cursos = $stmt_cursos->fetchAll(PDO::FETCH_ASSOC);
             $stmt_cursos->closeCursor();
 


### PR DESCRIPTION
This commit fixes a fatal error that occurred when creating or editing a price in the 'Lista de Precios por Curso' page.

The error was caused by calling the `sp_get_all_cursos` stored procedure without the required argument. The `create()` and `edit()` methods in `PrecioCursoController.php` have been updated to pass an empty string argument to the `execute()` call, which resolves the issue.