### PR TITLE
feat: Make final price editable in enrollment form

### DIFF
--- a/src/views/matriculas/create.php
+++ b/src/views/matriculas/create.php
@@ -125,7 +125,7 @@ $auth = new AuthController();
                 </div>
                  <div class="form-group">
                     <label for="precio_final">Precio Final (S/)</label>
-                    <input type="number" id="precio_final" name="precio_final" step="0.01" required readonly>
+                    <input type="number" id="precio_final" name="precio_final" step="0.01" required>
                 </div>
             </div>
             <div class="form-row">


### PR DESCRIPTION
This commit makes the 'Precio Final' field on the new enrollment page editable, allowing the user to override the automatically calculated price.

The `readonly` attribute has been removed from the `precio_final` input field in `src/views/matriculas/create.php`.

The system will still suggest a price based on the dynamic calculation, but the user now has the flexibility to enter a different final price before submitting the enrollment.