### PR TITLE
fix: Create missing sp_update_user stored procedure

### DIFF
--- a/db/IT-2025-08-27-feature-update-user-sp.sql
+++ b/db/IT-2025-08-27-feature-update-user-sp.sql
@@ -1,0 +1,22 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_update_user`$$
+
+CREATE PROCEDURE `sp_update_user`(
+    IN p_id_usuario INT,
+    IN p_nombre VARCHAR(100),
+    IN p_email VARCHAR(100)
+)
+BEGIN
+    -- Este procedimiento actualiza los datos básicos de un usuario (sin incluir la contraseña).
+    -- La contraseña se maneja en un procedimiento separado (sp_change_user_password)
+    -- para mayor seguridad y separación de lógica.
+
+    UPDATE `usuarios`
+    SET
+        `nombre` = p_nombre,
+        `email` = p_email
+    WHERE `id_usuario` = p_id_usuario;
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
This commit fixes a fatal error that occurred when updating a user's information.

The error was caused by the application calling a stored procedure, `sp_update_user`, that did not exist in the database. This commit adds a new SQL script to create the missing procedure.

The new procedure, `sp_update_user`, accepts a user ID, name, and email, and updates the corresponding record in the `usuarios` table.