### PR TITLE
fix: Display correct period on enrollment edit page

### DIFF
--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -112,19 +112,6 @@ class MatriculaController {
             $curso_id = $curso_id_result['id_curso'];
             $stmt_curso_id->closeCursor();
 
-            // Obtener el período (fecha_inicio y fecha_fin) del curso actual
-            $stmt_periodo = $db->prepare("SELECT fecha_inicio, fecha_fin FROM precios_cursos WHERE id_curso = ? AND CURDATE() BETWEEN fecha_inicio AND fecha_fin ORDER BY id_tipo_precio DESC LIMIT 1");
-            $stmt_periodo->execute([$curso_id]);
-            $periodo_curso = $stmt_periodo->fetch(PDO::FETCH_ASSOC);
-            $stmt_periodo->closeCursor();
-
-            // Añadir el período a los datos de la matrícula para que esté disponible en la vista
-            if ($periodo_curso) {
-                $matricula['fecha_inicio_curso'] = $periodo_curso['fecha_inicio'];
-                $matricula['fecha_fin_curso'] = $periodo_curso['fecha_fin'];
-            }
-
-
             // Obtener otros horarios disponibles para ese curso
             $stmt_horarios = $db->prepare("CALL sp_get_horarios_disponibles_por_curso(?, ?, ?, ?)");
             $stmt_horarios->execute([$curso_id, 0, null, null]); // Se pasan valores por defecto para los filtros no usados aquí

--- a/src/views/matriculas/edit.php
+++ b/src/views/matriculas/edit.php
@@ -24,7 +24,7 @@ $auth = new AuthController();
         <h4>Información Actual</h4>
         <p><strong>Alumno:</strong> <?php echo htmlspecialchars($matricula['alumno_nombre']); ?></p>
         <p><strong>Curso:</strong> <?php echo htmlspecialchars($matricula['curso_nombre']); ?></p>
-        <p><strong>Periodo del Curso:</strong> <?php echo isset($matricula['fecha_inicio_curso']) ? htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_inicio_curso']))) . ' - ' . htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_fin_curso']))) : 'No definido'; ?></p>
+        <p><strong>Periodo de Matrícula:</strong> <?php echo htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_inicio']))) . ' - ' . htmlspecialchars(date('d/m/Y', strtotime($matricula['fecha_fin']))); ?></p>
         <p><strong>Horario Actual:</strong> <?php echo htmlspecialchars($matricula['tipo_horario_nombre']); ?> de <?php echo htmlspecialchars(date('h:i A', strtotime($matricula['hora_inicio']))) . ' a ' . htmlspecialchars(date('h:i A', strtotime($matricula['hora_fin']))); ?> (Prof. <?php echo htmlspecialchars($matricula['profesor_nombre']); ?>)</p>
         <p><strong>Lugar:</strong> <?php echo htmlspecialchars($matricula['carril_nombre']); ?></p>
     </div>


### PR DESCRIPTION
This commit fixes an issue on the 'Cambiar Horario de Matrícula' (Change Enrollment Schedule) page where an incorrect course period was being displayed.

The `edit()` method in `MatriculaController.php` was fetching a generic course period from the `precios_cursos` table, which overwrote the actual start and end dates for the specific enrollment.

This change removes the incorrect code from the controller and updates the view (`src/views/matriculas/edit.php`) to display the correct `fecha_inicio` and `fecha_fin` from the enrollment record itself.