### PR TITLE
fix: Exclude current schedule from change schedule list

### DIFF
--- a/db/IT-2025-08-27-fix-exclude-current-schedule.sql
+++ b/db/IT-2025-08-27-fix-exclude-current-schedule.sql
@@ -1,0 +1,56 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_get_horarios_disponibles_por_curso`$$
+
+CREATE PROCEDURE `sp_get_horarios_disponibles_por_curso`(
+    IN p_id_curso INT,
+    IN p_id_profesor INT,
+    IN p_hora_inicio TIME,
+    IN p_hora_fin TIME,
+    IN p_id_horario_a_excluir INT
+)
+BEGIN
+    -- Se modifica para aceptar un ID de horario a excluir de los resultados.
+    -- Esto se usa en la página "Cambiar Horario" para no mostrar el horario actual
+    -- en la lista de nuevas opciones.
+
+    SELECT
+        h.id_horario,
+        c.nombre AS curso_nombre,
+        COALESCE(
+            (SELECT pc.precio
+             FROM precios_cursos pc
+             WHERE pc.id_curso = h.id_curso
+               AND h.fecha_inicio >= pc.fecha_inicio
+               AND h.fecha_fin <= pc.fecha_fin
+             LIMIT 1),
+            0.00
+        ) AS precio_actual,
+        h.fecha_inicio,
+        h.fecha_fin,
+        CONCAT(p.nombres, ' ', p.apellidos) AS profesor_nombre,
+        CONCAT(pi.nombre, ' - Carril ', ca.numero_carril) as carril_nombre,
+        th.nombre as tipo_horario_nombre,
+        th.dias_semana,
+        h.hora_inicio,
+        h.hora_fin,
+        (ca.capacidad_maxima - (
+            SELECT COUNT(*)
+            FROM matriculas m
+            WHERE m.id_horario = h.id_horario AND m.estado IN ('activa', 'vigente')
+        )) AS vacantes_disponibles
+    FROM horarios h
+    JOIN cursos c ON h.id_curso = c.id_curso
+    JOIN profesores p ON h.id_profesor = p.id_profesor
+    JOIN carriles ca ON h.id_carril = ca.id_carril
+    JOIN piscinas pi ON ca.id_piscina = pi.id_piscina
+    JOIN tipos_horario th ON h.id_tipo_horario = th.id_tipo_horario
+    WHERE h.id_curso = p_id_curso
+      AND (p_id_profesor = 0 OR h.id_profesor = p.id_profesor)
+      AND (p_hora_inicio IS NULL OR h.hora_inicio >= p_hora_inicio)
+      AND (p_hora_fin IS NULL OR h.hora_fin <= p_hora_fin)
+      AND (p_id_horario_a_excluir = 0 OR h.id_horario != p_id_horario_a_excluir) -- Condición añadida
+    HAVING vacantes_disponibles > 0;
+END$$
+
+DELIMITER ;

--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -112,19 +112,11 @@ class MatriculaController {
             $curso_id = $curso_id_result['id_curso'];
             $stmt_curso_id->closeCursor();
 
-            // Obtener otros horarios disponibles para ese curso
-            $stmt_horarios = $db->prepare("CALL sp_get_horarios_disponibles_por_curso(?, ?, ?, ?)");
-            $stmt_horarios->execute([$curso_id, 0, null, null]); // Se pasan valores por defecto para los filtros no usados aquí
+            // Obtener otros horarios disponibles para ese curso, excluyendo el actual
+            $stmt_horarios = $db->prepare("CALL sp_get_horarios_disponibles_por_curso(?, ?, ?, ?, ?)");
+            $stmt_horarios->execute([$curso_id, 0, null, null, $matricula['id_horario']]);
             $horarios_disponibles = $stmt_horarios->fetchAll(PDO::FETCH_ASSOC);
             $stmt_horarios->closeCursor();
-
-            // Excluir el horario actual de la lista de horarios disponibles
-            if (isset($matricula['id_horario'])) {
-                $current_horario_id = $matricula['id_horario'];
-                $horarios_disponibles = array_filter($horarios_disponibles, function($horario) use ($current_horario_id) {
-                    return $horario['id_horario'] != $current_horario_id;
-                });
-            }
 
             require_once __DIR__ . '/../views/matriculas/edit.php';
 
@@ -220,8 +212,8 @@ class MatriculaController {
 
         $db = Database::getInstance()->getConnection();
         try {
-            $stmt = $db->prepare("CALL sp_get_horarios_disponibles_por_curso(?, ?, ?, ?)");
-            $stmt->execute([$id_curso, $id_profesor, $hora_inicio, $hora_fin]);
+            $stmt = $db->prepare("CALL sp_get_horarios_disponibles_por_curso(?, ?, ?, ?, ?)");
+            $stmt->execute([$id_curso, $id_profesor, $hora_inicio, $hora_fin, 0]); // 0 para no excluir ningún horario
             $horarios = $stmt->fetchAll(PDO::FETCH_ASSOC);
             echo json_encode($horarios);
         } catch (PDOException $e) {


### PR DESCRIPTION
This commit fixes an issue on the 'Cambiar Horario de Matrícula' page where the student's current schedule was being displayed in the list of available new schedules.

- The `sp_get_horarios_disponibles_por_curso` stored procedure has been updated to accept a new parameter, `p_id_horario_a_excluir`, to filter out a specific schedule ID.
- The `edit()` method in `MatriculaController.php` has been updated to pass the current schedule's ID to this new parameter, moving the filtering logic from PHP to the database.
- The `getHorariosByCurso()` method was also updated to pass `0` for the new parameter to ensure it doesn't affect the new enrollment page.