### PR TITLE
refactor: Remove redundant text from change schedule page

### DIFF
--- a/src/views/matriculas/edit.php
+++ b/src/views/matriculas/edit.php
@@ -35,7 +35,6 @@ $auth = new AuthController();
         <input type="hidden" name="csrf_token" value="<?php echo $auth->getCsrfToken(); ?>">
         <input type="hidden" name="id_matricula" value="<?php echo htmlspecialchars($matricula['id_matricula']); ?>">
 
-        <h4>Seleccione un Nuevo Horario (si desea cambiarlo)</h4>
         <input type="hidden" id="id_horario" name="id_horario" value="<?php echo htmlspecialchars($matricula['id_horario']); ?>" required>
 
         <div class="horarios-list">


### PR DESCRIPTION
This commit removes a redundant `<h4>` heading, 'Seleccione un Nuevo Horario (si desea cambiarlo)', from the 'Cambiar Horario de Matrícula' page to simplify the user interface.