### PR TITLE
refactor: Update Dashboard text and rename to Monitor

### DIFF
--- a/src/views/dashboard.php
+++ b/src/views/dashboard.php
@@ -9,11 +9,8 @@ require_once __DIR__ . '/partials/header.php';
 ?>
 
 <div class="dashboard-container" style="padding: 2rem;">
-    <h2>Panel de Administración</h2>
-    <p>¡Bienvenido de nuevo, <?php echo htmlspecialchars($_SESSION['user_name']); ?>!</p>
-    <p>Desde aquí podrás gestionar todo el sistema de matrículas de natación.</p>
-
-    <p>A continuación se muestran los horarios con vacantes disponibles. Seleccione uno para iniciar una matrícula rápida.</p>
+    <h2>Monitor de Matriculas</h2>
+    <p>Seleccione un curso para iniciar una matricula rápida.</p>
 
     <div class="dashboard-actions" style="margin-bottom: 1rem; display: flex; align-items: center; gap: 1rem;">
         <button id="refresh-btn" class="btn btn-secondary">Actualizar Listado</button>

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -70,7 +70,7 @@ if (!defined('BASE_URL')) {
             <h1><a href="<?php echo BASE_URL; ?>index.php?url=dashboard">NataciónSys</a></h1>
             <div class="nav-links">
                 <?php if (isset($_SESSION['user_id'])): ?>
-                    <a href="<?php echo BASE_URL; ?>index.php?url=dashboard">Dashboard</a>
+                    <a href="<?php echo BASE_URL; ?>index.php?url=dashboard">Monitor</a>
 
                     <div class="dropdown">
                         <a href="#">Configuración &#9662;</a>


### PR DESCRIPTION
This commit applies several text changes to the Dashboard page and the main navigation menu based on user feedback.

- The 'Dashboard' menu item in `header.php` is renamed to 'Monitor'.
- On the Dashboard page (`dashboard.php`):
  - The main title is changed from 'Panel de Administración' to 'Monitor de Matriculas'.
  - The welcome messages are removed.
  - The instructional text is updated to 'Seleccione un curso para iniciar una matricula rápida'.