### PR TITLE
feat: Add new Inicio page with summary charts

### DIFF
--- a/db/IT-2025-08-27-feature-inicio-charts.sql
+++ b/db/IT-2025-08-27-feature-inicio-charts.sql
@@ -1,0 +1,62 @@
+DELIMITER $$
+
+-- Gráfico 1: Ventas mensuales por curso (año actual)
+DROP PROCEDURE IF EXISTS `sp_get_ventas_por_curso_mensual_anual`$$
+CREATE PROCEDURE `sp_get_ventas_por_curso_mensual_anual`()
+BEGIN
+    SELECT
+        MONTH(m.fecha_matricula) AS mes,
+        c.nombre AS curso_nombre,
+        SUM(m.precio_final) AS total_ventas
+    FROM matriculas m
+    JOIN horarios h ON m.id_horario = h.id_horario
+    JOIN cursos c ON h.id_curso = c.id_curso
+    WHERE YEAR(m.fecha_matricula) = YEAR(CURDATE()) AND m.estado != 'anulada'
+    GROUP BY MONTH(m.fecha_matricula), c.nombre
+    ORDER BY mes, curso_nombre;
+END$$
+
+-- Gráfico 2: Ventas totales por curso (año actual)
+DROP PROCEDURE IF EXISTS `sp_get_ventas_por_curso_anual`$$
+CREATE PROCEDURE `sp_get_ventas_por_curso_anual`()
+BEGIN
+    SELECT
+        c.nombre AS curso_nombre,
+        SUM(m.precio_final) AS total_ventas
+    FROM matriculas m
+    JOIN horarios h ON m.id_horario = h.id_horario
+    JOIN cursos c ON h.id_curso = c.id_curso
+    WHERE YEAR(m.fecha_matricula) = YEAR(CURDATE()) AND m.estado != 'anulada'
+    GROUP BY c.nombre;
+END$$
+
+-- Gráfico 3: Ventas totales por forma de pago (año actual)
+DROP PROCEDURE IF EXISTS `sp_get_ventas_por_forma_pago_anual`$$
+CREATE PROCEDURE `sp_get_ventas_por_forma_pago_anual`()
+BEGIN
+    SELECT
+        fp.nombre AS forma_pago,
+        SUM(m.precio_final) AS total_ventas
+    FROM matriculas m
+    JOIN formas_pago fp ON m.id_forma_pago = fp.id_forma_pago
+    WHERE YEAR(m.fecha_matricula) = YEAR(CURDATE()) AND m.estado != 'anulada'
+    GROUP BY fp.nombre;
+END$$
+
+-- Gráfico 4: Ventas totales por tipo de piscina (año actual)
+DROP PROCEDURE IF EXISTS `sp_get_ventas_por_piscina_anual`$$
+CREATE PROCEDURE `sp_get_ventas_por_piscina_anual`()
+BEGIN
+    SELECT
+        tp.nombre AS tipo_piscina,
+        SUM(m.precio_final) AS total_ventas
+    FROM matriculas m
+    JOIN horarios h ON m.id_horario = h.id_horario
+    JOIN carriles ca ON h.id_carril = ca.id_carril
+    JOIN piscinas pi ON ca.id_piscina = pi.id_piscina
+    JOIN tipos_piscina tp ON pi.id_tipo_piscina = tp.id_tipo_piscina
+    WHERE YEAR(m.fecha_matricula) = YEAR(CURDATE()) AND m.estado != 'anulada'
+    GROUP BY tp.nombre;
+END$$
+
+DELIMITER ;

--- a/public/index.php
+++ b/public/index.php
@@ -27,6 +27,7 @@ require_once '../src/controllers/ReporteController.php';
 require_once '../src/controllers/TipoPrecioController.php';
 require_once '../src/controllers/PrecioCursoController.php';
 require_once '../src/controllers/DashboardController.php';
+require_once '../src/controllers/InicioController.php';
 
 
 // Simple enrutador basado en el parámetro 'url'
@@ -307,9 +308,14 @@ switch ($route) {
         }
         break;
 
+    case 'inicio':
+        $inicioController = new InicioController();
+        $inicioController->index();
+        break;
+
     case 'home':
         if (isset($_SESSION['user_id'])) {
-            header('Location: index.php?url=dashboard');
+            header('Location: index.php?url=inicio'); // Redirigir a la nueva página de inicio
         } else {
             header('Location: index.php?url=login');
         }

--- a/src/controllers/InicioController.php
+++ b/src/controllers/InicioController.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+require_once __DIR__ . '/AuthController.php';
+
+class InicioController {
+
+    private $auth;
+
+    public function __construct() {
+        $this->auth = new AuthController();
+        $this->auth->checkAuth();
+    }
+
+    public function index() {
+        $db = Database::getInstance()->getConnection();
+        $chart_data = [];
+
+        try {
+            // Datos para Gráfico 1: Ventas mensuales por curso
+            $stmt1 = $db->prepare("CALL sp_get_ventas_por_curso_mensual_anual()");
+            $stmt1->execute();
+            $chart_data['ventas_mensuales_por_curso'] = $stmt1->fetchAll(PDO::FETCH_ASSOC);
+            $stmt1->closeCursor();
+
+            // Datos para Gráfico 2: Ventas totales por curso
+            $stmt2 = $db->prepare("CALL sp_get_ventas_por_curso_anual()");
+            $stmt2->execute();
+            $chart_data['ventas_por_curso'] = $stmt2->fetchAll(PDO::FETCH_ASSOC);
+            $stmt2->closeCursor();
+
+            // Datos para Gráfico 3: Ventas por forma de pago
+            $stmt3 = $db->prepare("CALL sp_get_ventas_por_forma_pago_anual()");
+            $stmt3->execute();
+            $chart_data['ventas_por_forma_pago'] = $stmt3->fetchAll(PDO::FETCH_ASSOC);
+            $stmt3->closeCursor();
+
+            // Datos para Gráfico 4: Ventas por tipo de piscina
+            $stmt4 = $db->prepare("CALL sp_get_ventas_por_piscina_anual()");
+            $stmt4->execute();
+            $chart_data['ventas_por_piscina'] = $stmt4->fetchAll(PDO::FETCH_ASSOC);
+            $stmt4->closeCursor();
+
+        } catch (PDOException $e) {
+            $_SESSION['error_message'] = "Error al cargar los datos para los gráficos: " . $e->getMessage();
+        }
+
+        require_once __DIR__ . '/../views/inicio/index.php';
+    }
+}
+?>

--- a/src/views/inicio/index.php
+++ b/src/views/inicio/index.php
@@ -1,0 +1,159 @@
+<?php
+require_once __DIR__ . '/../partials/header.php';
+?>
+
+<style>
+.chart-container {
+    width: 100%;
+    max-width: 900px;
+    margin: 2rem auto;
+    padding: 2rem;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #fff;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.05);
+}
+.chart-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2rem;
+}
+</style>
+
+<div class="container">
+    <div class="page-header">
+        <h1>Inicio</h1>
+    </div>
+
+    <?php if (isset($_SESSION['error_message'])): ?>
+        <div class="error-message"><?php echo htmlspecialchars($_SESSION['error_message']); unset($_SESSION['error_message']); ?></div>
+    <?php endif; ?>
+
+    <div class="chart-container">
+        <h3>Ventas Mensuales por Curso (Año Actual)</h3>
+        <canvas id="ventasMensualesChart"></canvas>
+    </div>
+
+    <div class="chart-grid">
+        <div class="chart-container">
+            <h3>Ventas por Curso (Año Actual)</h3>
+            <canvas id="ventasPorCursoChart"></canvas>
+        </div>
+        <div class="chart-container">
+            <h3>Ventas por Forma de Pago (Año Actual)</h3>
+            <canvas id="ventasPorFormaPagoChart"></canvas>
+        </div>
+        <div class="chart-container">
+            <h3>Ventas por Tipo de Piscina (Año Actual)</h3>
+            <canvas id="ventasPorPiscinaChart"></canvas>
+        </div>
+    </div>
+</div>
+
+<!-- Incluir Chart.js desde CDN -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Obtener datos desde PHP
+    const chartData = <?php echo json_encode($chart_data ?? []); ?>;
+
+    // --- Colores para los gráficos ---
+    const backgroundColors = [
+        'rgba(255, 99, 132, 0.7)', 'rgba(54, 162, 235, 0.7)',
+        'rgba(255, 206, 86, 0.7)', 'rgba(75, 192, 192, 0.7)',
+        'rgba(153, 102, 255, 0.7)', 'rgba(255, 159, 64, 0.7)',
+        'rgba(199, 199, 199, 0.7)', 'rgba(83, 102, 255, 0.7)',
+        'rgba(40, 159, 64, 0.7)', 'rgba(210, 99, 132, 0.7)'
+    ];
+
+    // --- Gráfico 1: Ventas Mensuales por Curso (Barras Apiladas) ---
+    const ventasMensualesData = chartData.ventas_mensuales_por_curso || [];
+    const meses = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
+    const cursos = [...new Set(ventasMensualesData.map(d => d.curso_nombre))];
+    const datasetsVentasMensuales = cursos.map((curso, index) => {
+        const data = meses.map((_, mesIndex) => {
+            const mesNum = mesIndex + 1;
+            const record = ventasMensualesData.find(d => d.mes == mesNum && d.curso_nombre === curso);
+            return record ? record.total_ventas : 0;
+        });
+        return {
+            label: curso,
+            data: data,
+            backgroundColor: backgroundColors[index % backgroundColors.length],
+        };
+    });
+
+    if (document.getElementById('ventasMensualesChart')) {
+        new Chart(document.getElementById('ventasMensualesChart'), {
+            type: 'bar',
+            data: {
+                labels: meses,
+                datasets: datasetsVentasMensuales
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    x: { stacked: true },
+                    y: { stacked: true, beginAtZero: true }
+                }
+            }
+        });
+    }
+
+    // --- Función auxiliar para gráficos circulares ---
+    function createPieChart(canvasId, rawData, labelField, dataField) {
+        const canvas = document.getElementById(canvasId);
+        if (!canvas || !rawData || rawData.length === 0) return;
+
+        const labels = rawData.map(d => d[labelField]);
+        const data = rawData.map(d => d[dataField]);
+
+        new Chart(canvas, {
+            type: 'pie',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: backgroundColors,
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { position: 'top' },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                let label = context.label || '';
+                                if (label) {
+                                    label += ': ';
+                                }
+                                if (context.parsed !== null) {
+                                    const total = context.chart.data.datasets[0].data.reduce((a, b) => a + b, 0);
+                                    const percentage = total > 0 ? (context.raw / total * 100).toFixed(2) : 0;
+                                    label += `S/ ${context.raw} (${percentage}%)`;
+                                }
+                                return label;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // --- Gráfico 2: Ventas por Curso (Circular) ---
+    createPieChart('ventasPorCursoChart', chartData.ventas_por_curso, 'curso_nombre', 'total_ventas');
+
+    // --- Gráfico 3: Ventas por Forma de Pago (Circular) ---
+    createPieChart('ventasPorFormaPagoChart', chartData.ventas_por_forma_pago, 'forma_pago', 'total_ventas');
+
+    // --- Gráfico 4: Ventas por Tipo de Piscina (Circular) ---
+    createPieChart('ventasPorPiscinaChart', chartData.ventas_por_piscina, 'tipo_piscina', 'total_ventas');
+});
+</script>
+
+<?php
+require_once __DIR__ . '/../partials/footer.php';
+?>

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -67,9 +67,10 @@ if (!defined('BASE_URL')) {
 <body>
     <header>
         <nav>
-            <h1><a href="<?php echo BASE_URL; ?>index.php?url=dashboard">NataciónSys</a></h1>
+            <h1><a href="<?php echo BASE_URL; ?>index.php?url=inicio">NataciónSys</a></h1>
             <div class="nav-links">
                 <?php if (isset($_SESSION['user_id'])): ?>
+                    <a href="<?php echo BASE_URL; ?>index.php?url=inicio">Inicio</a>
                     <a href="<?php echo BASE_URL; ?>index.php?url=dashboard">Monitor</a>
 
                     <div class="dropdown">


### PR DESCRIPTION
This commit introduces a new 'Inicio' (Home) page that serves as the main dashboard, displaying several summary charts.

- Creates four new stored procedures to gather sales data for the current year, aggregated by different criteria.
- Adds a new `InicioController` to fetch the data for the charts.
- Creates a new `inicio/index.php` view that uses Chart.js to render four charts:
  - Bar chart of monthly sales by course.
  - Pie chart of total sales by course.
  - Pie chart of total sales by payment method.
  - Pie chart of total sales by pool type.
- Updates the main navigation menu to include the 'Inicio' link as the first item.
- Sets 'Inicio' as the new default landing page for logged-in users.