### PR TITLE
fix: Reduce size of pie charts on Inicio page

### DIFF
--- a/src/views/inicio/index.php
+++ b/src/views/inicio/index.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../partials/header.php';
 }
 .chart-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); /* Reducido al 40% */
     gap: 3.5rem; /* Aumentada más la separación */
 }
 .form-control { /* Estilo básico para los select */


### PR DESCRIPTION
This commit addresses a user request to reduce the size of the pie charts on the 'Inicio' page for a better layout.

The CSS for the `.chart-grid` in `src/views/inicio/index.php` has been updated to reduce the minimum width of the chart containers, effectively shrinking the pie charts.