### PR TITLE
Fix(matriculas): Remove base price from enrollment details view

### DIFF
--- a/src/views/matriculas/show.php
+++ b/src/views/matriculas/show.php
@@ -69,9 +69,6 @@ function get_spanish_day_name($date_str) {
             <strong>Forma de Pago:</strong> <?php echo htmlspecialchars($matricula['forma_pago_nombre'] ?? 'No especificado'); ?>
         </div>
         <div class="detail-item">
-            <strong>Precio Base:</strong> S/ <?php echo htmlspecialchars(number_format($matricula['precio_base'] ?? 0, 2)); ?>
-        </div>
-        <div class="detail-item">
             <strong>Descuento:</strong> S/ <?php echo htmlspecialchars(number_format($matricula['descuento'] ?? 0, 2)); ?>
         </div>
         <div class="detail-item">


### PR DESCRIPTION
This commit removes the 'Precio Base' field from the enrollment details page as requested by the user. This simplifies the view to only show the most relevant financial information: discount and final price.