### PR TITLE
fix: Correct percentage calculation in pie charts

### DIFF
--- a/src/views/inicio/index.php
+++ b/src/views/inicio/index.php
@@ -147,7 +147,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!canvas || !rawData || rawData.length === 0) return;
 
         const labels = rawData.map(d => d[labelField]);
-        const data = rawData.map(d => d[dataField]);
+        const data = rawData.map(d => parseFloat(d[dataField]) || 0);
 
         new Chart(canvas, {
             type: 'pie',


### PR DESCRIPTION
- Ensures that the data values for pie charts are parsed as numbers before being used in calculations.
- This prevents the reduce function from performing string concatenation, which resulted in an incorrect total and zero percentages.