### PR TITLE
fix: Prevent form submission on duplicate DNI

### DIFF
--- a/src/views/alumnos/create.php
+++ b/src/views/alumnos/create.php
@@ -96,15 +96,19 @@ require_once __DIR__ . '/../partials/footer.php';
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    const form = document.querySelector('form');
     const dniInput = document.getElementById('documento_identidad');
     const dniError = document.getElementById('dni-error');
     const submitButton = document.querySelector('button[type="submit"]');
+
+    let isDniDuplicate = false;
 
     dniInput.addEventListener('blur', function() {
         const dni = this.value.trim();
         if (dni === '') {
             dniError.style.display = 'none';
             submitButton.disabled = false;
+            isDniDuplicate = false;
             return;
         }
 
@@ -115,16 +119,25 @@ document.addEventListener('DOMContentLoaded', function() {
                     dniError.textContent = 'Este documento de identidad ya está registrado.';
                     dniError.style.display = 'block';
                     submitButton.disabled = true;
+                    isDniDuplicate = true;
                 } else {
                     dniError.style.display = 'none';
                     submitButton.disabled = false;
+                    isDniDuplicate = false;
                 }
             })
             .catch(error => {
                 console.error('Error al verificar el DNI:', error);
-                // En caso de error de red, permitir el envío para que la validación del backend actúe
                 submitButton.disabled = false;
+                isDniDuplicate = false;
             });
+    });
+
+    form.addEventListener('submit', function(event) {
+        if (isDniDuplicate) {
+            event.preventDefault();
+            alert('No se puede guardar el alumno porque el documento de identidad ya existe.');
+        }
     });
 });
 </script>

--- a/src/views/matriculas/create.php
+++ b/src/views/matriculas/create.php
@@ -423,13 +423,17 @@ document.getElementById('form-matricula').addEventListener('submit', function(ev
 // DNI validation for new student
 const nuevoDniInput = document.querySelector('[name="nuevo_alumno_documento"]');
 const nuevoDniError = document.getElementById('nuevo-dni-error');
+const mainForm = document.getElementById('form-matricula');
 const submitButton = document.querySelector('#form-matricula button[type="submit"]');
+
+let isNuevoDniDuplicate = false;
 
 nuevoDniInput.addEventListener('blur', function() {
     const dni = this.value.trim();
     if (dni === '') {
         nuevoDniError.style.display = 'none';
         submitButton.disabled = false;
+        isNuevoDniDuplicate = false;
         return;
     }
 
@@ -440,15 +444,25 @@ nuevoDniInput.addEventListener('blur', function() {
                 nuevoDniError.textContent = 'Este documento ya está registrado.';
                 nuevoDniError.style.display = 'block';
                 submitButton.disabled = true;
+                isNuevoDniDuplicate = true;
             } else {
                 nuevoDniError.style.display = 'none';
                 submitButton.disabled = false;
+                isNuevoDniDuplicate = false;
             }
         })
         .catch(error => {
             console.error('Error al verificar el DNI:', error);
             submitButton.disabled = false;
+            isNuevoDniDuplicate = false;
         });
+});
+
+mainForm.addEventListener('submit', function(event) {
+    if (isNuevoDniDuplicate) {
+        event.preventDefault();
+        alert('No se puede registrar la matrícula porque el documento del nuevo alumno ya existe.');
+    }
 });
 </script>
 


### PR DESCRIPTION
- Adds a `submit` event listener to the 'Add Student' and 'New Enrollment' forms.
- This listener prevents the form from being submitted if the DNI validation has failed, providing a more robust user experience and preventing backend errors.