### PR TITLE
feat: Add document type maintenance and integration

### DIFF
--- a/db/feature-tipo-documento.sql
+++ b/db/feature-tipo-documento.sql
@@ -1,0 +1,167 @@
+-- =================================================================
+-- ARCHIVO DE SCRIPT PARA LA FUNCIONALIDAD DE TIPOS DE DOCUMENTO
+-- =================================================================
+
+--
+-- 1. Creación de la nueva tabla `tipos_documento`
+--
+CREATE TABLE IF NOT EXISTS `tipos_documento` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `descripcion` VARCHAR(100) NOT NULL,
+  `longitud` INT NOT NULL,
+  `sunat` VARCHAR(3) NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Insertar algunos valores por defecto
+INSERT INTO `tipos_documento` (`descripcion`, `longitud`, `sunat`) VALUES
+('DNI', 8, '1'),
+('RUC', 11, '6'),
+('Carnet de Extranjería', 12, '4'),
+('Pasaporte', 12, '7'),
+('Otro', 20, '0');
+
+
+--
+-- 2. Modificación de la tabla `alumnos`
+--
+ALTER TABLE `alumnos`
+ADD COLUMN `id_tipo_documento` INT NULL DEFAULT 1 AFTER `apellidos`,
+ADD CONSTRAINT `fk_alumnos_tipos_documento` FOREIGN KEY (`id_tipo_documento`) REFERENCES `tipos_documento`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+
+--
+-- 3. Procedimientos Almacenados para el CRUD de `tipos_documento`
+--
+
+DELIMITER $$
+
+-- Crear un nuevo tipo de documento
+CREATE PROCEDURE `sp_create_tipo_documento`(
+    IN p_descripcion VARCHAR(100),
+    IN p_longitud INT,
+    IN p_sunat VARCHAR(3)
+)
+BEGIN
+    INSERT INTO tipos_documento (descripcion, longitud, sunat)
+    VALUES (p_descripcion, p_longitud, p_sunat);
+END$$
+
+-- Obtener todos los tipos de documento
+CREATE PROCEDURE `sp_get_all_tipos_documento`()
+BEGIN
+    SELECT id, descripcion, longitud, sunat FROM tipos_documento ORDER BY descripcion;
+END$$
+
+-- Obtener un tipo de documento por ID
+CREATE PROCEDURE `sp_get_tipo_documento_by_id`(
+    IN p_id INT
+)
+BEGIN
+    SELECT id, descripcion, longitud, sunat FROM tipos_documento WHERE id = p_id;
+END$$
+
+-- Actualizar un tipo de documento
+CREATE PROCEDURE `sp_update_tipo_documento`(
+    IN p_id INT,
+    IN p_descripcion VARCHAR(100),
+    IN p_longitud INT,
+    IN p_sunat VARCHAR(3)
+)
+BEGIN
+    UPDATE tipos_documento
+    SET
+        descripcion = p_descripcion,
+        longitud = p_longitud,
+        sunat = p_sunat
+    WHERE id = p_id;
+END$$
+
+-- Eliminar un tipo de documento
+CREATE PROCEDURE `sp_delete_tipo_documento`(
+    IN p_id INT
+)
+BEGIN
+    DELETE FROM tipos_documento WHERE id = p_id;
+END$$
+
+DELIMITER ;
+
+
+--
+-- 4. Actualización de los Procedimientos Almacenados de `alumnos`
+--
+
+DELIMITER $$
+
+-- Eliminar los procedimientos antiguos para poder recrearlos
+DROP PROCEDURE IF EXISTS `sp_create_alumno`;
+DROP PROCEDURE IF EXISTS `sp_update_alumno`;
+DROP PROCEDURE IF EXISTS `sp_create_alumno_simple`;
+
+-- Recrear `sp_create_alumno` con el nuevo campo
+CREATE PROCEDURE `sp_create_alumno`(
+    IN p_nombres VARCHAR(100),
+    IN p_apellidos VARCHAR(100),
+    IN p_id_tipo_documento INT,
+    IN p_documento_identidad VARCHAR(20),
+    IN p_fecha_nacimiento DATE,
+    IN p_grupo_sanguineo VARCHAR(5),
+    IN p_direccion VARCHAR(255),
+    IN p_telefono VARCHAR(20),
+    IN p_email VARCHAR(100),
+    IN p_nombre_padre_tutor VARCHAR(200),
+    IN p_telefono_emergencia VARCHAR(20)
+)
+BEGIN
+    INSERT INTO alumnos (nombres, apellidos, id_tipo_documento, documento_identidad, fecha_nacimiento, grupo_sanguineo, direccion, telefono, email, nombre_padre_tutor, telefono_emergencia)
+    VALUES (p_nombres, p_apellidos, p_id_tipo_documento, p_documento_identidad, p_fecha_nacimiento, p_grupo_sanguineo, p_direccion, p_telefono, p_email, p_nombre_padre_tutor, p_telefono_emergencia);
+END$$
+
+-- Recrear `sp_update_alumno` con el nuevo campo
+CREATE PROCEDURE `sp_update_alumno`(
+    IN p_id_alumno INT,
+    IN p_nombres VARCHAR(100),
+    IN p_apellidos VARCHAR(100),
+    IN p_id_tipo_documento INT,
+    IN p_documento_identidad VARCHAR(20),
+    IN p_fecha_nacimiento DATE,
+    IN p_grupo_sanguineo VARCHAR(5),
+    IN p_direccion VARCHAR(255),
+    IN p_telefono VARCHAR(20),
+    IN p_email VARCHAR(100),
+    IN p_nombre_padre_tutor VARCHAR(200),
+    IN p_telefono_emergencia VARCHAR(20)
+)
+BEGIN
+    UPDATE alumnos
+    SET
+        nombres = p_nombres,
+        apellidos = p_apellidos,
+        id_tipo_documento = p_id_tipo_documento,
+        documento_identidad = p_documento_identidad,
+        fecha_nacimiento = p_fecha_nacimiento,
+        grupo_sanguineo = p_grupo_sanguineo,
+        direccion = p_direccion,
+        telefono = p_telefono,
+        email = p_email,
+        nombre_padre_tutor = p_nombre_padre_tutor,
+        telefono_emergencia = p_telefono_emergencia
+    WHERE id_alumno = p_id_alumno;
+END$$
+
+-- Crear `sp_create_alumno_simple` con el nuevo campo
+CREATE PROCEDURE `sp_create_alumno_simple`(
+    IN p_nombres VARCHAR(100),
+    IN p_apellidos VARCHAR(100),
+    IN p_id_tipo_documento INT,
+    IN p_documento_identidad VARCHAR(20),
+    IN p_telefono VARCHAR(20),
+    IN p_email VARCHAR(100)
+)
+BEGIN
+    INSERT INTO alumnos (nombres, apellidos, id_tipo_documento, documento_identidad, telefono, email)
+    VALUES (p_nombres, p_apellidos, p_id_tipo_documento, p_documento_identidad, p_telefono, p_email);
+    SELECT LAST_INSERT_ID() as nuevo_alumno_id;
+END$$
+
+DELIMITER ;

--- a/src/controllers/AlumnoController.php
+++ b/src/controllers/AlumnoController.php
@@ -35,6 +35,16 @@ class AlumnoController {
      * Muestra el formulario para crear un nuevo alumno.
      */
     public function create() {
+        $db = Database::getInstance()->getConnection();
+        try {
+            $stmt = $db->prepare("CALL sp_get_all_tipos_documento()");
+            $stmt->execute();
+            $tipos_documento = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } catch (PDOException $e) {
+            // Manejar el error, quizás con un array vacío
+            $tipos_documento = [];
+            $_SESSION['error_message'] = "Error al cargar los tipos de documento: " . $e->getMessage();
+        }
         require_once __DIR__ . '/../views/alumnos/create.php';
     }
 
@@ -61,10 +71,11 @@ class AlumnoController {
 
             $db = Database::getInstance()->getConnection();
             try {
-                $stmt = $db->prepare("CALL sp_create_alumno(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                $stmt = $db->prepare("CALL sp_create_alumno(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                 $stmt->execute([
                     $_POST['nombres'],
                     $_POST['apellidos'],
+                    $_POST['id_tipo_documento'],
                     $dni,
                     $_POST['fecha_nacimiento'],
                     $_POST['grupo_sanguineo'],
@@ -99,9 +110,17 @@ class AlumnoController {
 
         $db = Database::getInstance()->getConnection();
         try {
-            $stmt = $db->prepare("CALL sp_get_alumno_by_id(?)");
-            $stmt->execute([$id]);
-            $alumno = $stmt->fetch(PDO::FETCH_ASSOC);
+            // Obtener tipos de documento
+            $stmt_tipos = $db->prepare("CALL sp_get_all_tipos_documento()");
+            $stmt_tipos->execute();
+            $tipos_documento = $stmt_tipos->fetchAll(PDO::FETCH_ASSOC);
+            $stmt_tipos->closeCursor();
+
+            // Obtener datos del alumno
+            $stmt_alumno = $db->prepare("CALL sp_get_alumno_by_id(?)");
+            $stmt_alumno->execute([$id]);
+            $alumno = $stmt_alumno->fetch(PDO::FETCH_ASSOC);
+            $stmt_alumno->closeCursor();
 
             if ($alumno) {
                 require_once __DIR__ . '/../views/alumnos/edit.php';
@@ -110,7 +129,7 @@ class AlumnoController {
                 echo "Alumno no encontrado.";
             }
         } catch (PDOException $e) {
-            echo "Error al buscar el alumno: " . $e->getMessage();
+            echo "Error al buscar el alumno o los tipos de documento: " . $e->getMessage();
         }
     }
 
@@ -135,11 +154,12 @@ class AlumnoController {
 
             $db = Database::getInstance()->getConnection();
             try {
-                $stmt = $db->prepare("CALL sp_update_alumno(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                $stmt = $db->prepare("CALL sp_update_alumno(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                 $stmt->execute([
                     $id,
                     $_POST['nombres'],
                     $_POST['apellidos'],
+                    $_POST['id_tipo_documento'],
                     $dni,
                     $_POST['fecha_nacimiento'],
                     $_POST['grupo_sanguineo'],

--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -215,6 +215,12 @@ class MatriculaController {
         $formas_pago = $stmt_formas_pago->fetchAll(PDO::FETCH_ASSOC);
         $stmt_formas_pago->closeCursor();
 
+        // Cargar tipos de documento para el formulario de nuevo alumno
+        $stmt_tipos_documento = $db->prepare("CALL sp_get_all_tipos_documento()");
+        $stmt_tipos_documento->execute();
+        $tipos_documento = $stmt_tipos_documento->fetchAll(PDO::FETCH_ASSOC);
+        $stmt_tipos_documento->closeCursor();
+
         require_once __DIR__ . '/../views/matriculas/create.php';
     }
 
@@ -337,10 +343,11 @@ class MatriculaController {
 
                 // Si no hay ID de alumno pero sí datos de nuevo alumno, crearlo primero
                 if (empty($id_alumno) && !empty($_POST['nuevo_alumno_nombres'])) {
-                    $stmt_nuevo_alumno = $db->prepare("CALL sp_create_alumno_simple(?, ?, ?, ?, ?)");
+                    $stmt_nuevo_alumno = $db->prepare("CALL sp_create_alumno_simple(?, ?, ?, ?, ?, ?)");
                     $stmt_nuevo_alumno->execute([
                         $_POST['nuevo_alumno_nombres'],
                         $_POST['nuevo_alumno_apellidos'],
+                        $_POST['nuevo_alumno_id_tipo_documento'],
                         $_POST['nuevo_alumno_documento'],
                         $_POST['nuevo_alumno_telefono'],
                         $_POST['nuevo_alumno_email']

--- a/src/controllers/TipoDocumentoController.php
+++ b/src/controllers/TipoDocumentoController.php
@@ -1,0 +1,118 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+require_once __DIR__ . '/AuthController.php';
+
+class TipoDocumentoController {
+
+    private $auth;
+
+    public function __construct() {
+        $this->auth = new AuthController();
+        $this->auth->checkAuth();
+    }
+
+    public function index() {
+        $db = Database::getInstance()->getConnection();
+        try {
+            $stmt = $db->prepare("CALL sp_get_all_tipos_documento()");
+            $stmt->execute();
+            $tipos_documento = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            require_once __DIR__ . '/../views/tipos_documento/index.php';
+        } catch (PDOException $e) {
+            echo "Error al cargar los tipos de documento: " . $e->getMessage();
+        }
+    }
+
+    public function create() {
+        require_once __DIR__ . '/../views/tipos_documento/create.php';
+    }
+
+    public function store() {
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $this->auth->verifyCsrfToken();
+            $db = Database::getInstance()->getConnection();
+            try {
+                $stmt = $db->prepare("CALL sp_create_tipo_documento(?, ?, ?)");
+                $stmt->execute([
+                    $_POST['descripcion'],
+                    $_POST['longitud'],
+                    $_POST['sunat']
+                ]);
+                header('Location: index.php?url=tipos_documento');
+                exit;
+            } catch (PDOException $e) {
+                $_SESSION['error_message'] = "Error al crear el tipo de documento: " . $e->getMessage();
+                header('Location: index.php?url=tipos_documento/create');
+                exit;
+            }
+        }
+    }
+
+    public function edit() {
+        $id = $_GET['id'] ?? null;
+        if (!$id) {
+            header('Location: index.php?url=tipos_documento');
+            exit;
+        }
+
+        $db = Database::getInstance()->getConnection();
+        try {
+            $stmt = $db->prepare("CALL sp_get_tipo_documento_by_id(?)");
+            $stmt->execute([$id]);
+            $tipo_documento = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if ($tipo_documento) {
+                require_once __DIR__ . '/../views/tipos_documento/edit.php';
+            } else {
+                http_response_code(404);
+                echo "Tipo de documento no encontrado.";
+            }
+        } catch (PDOException $e) {
+            echo "Error al buscar el tipo de documento: " . $e->getMessage();
+        }
+    }
+
+    public function update() {
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $this->auth->verifyCsrfToken();
+            $id = $_POST['id'] ?? null;
+            if (!$id) {
+                header('Location: index.php?url=tipos_documento');
+                exit;
+            }
+
+            $db = Database::getInstance()->getConnection();
+            try {
+                $stmt = $db->prepare("CALL sp_update_tipo_documento(?, ?, ?, ?)");
+                $stmt->execute([
+                    $id,
+                    $_POST['descripcion'],
+                    $_POST['longitud'],
+                    $_POST['sunat']
+                ]);
+                header('Location: index.php?url=tipos_documento');
+                exit;
+            } catch (PDOException $e) {
+                $_SESSION['error_message'] = "Error al actualizar el tipo de documento: " . $e->getMessage();
+                header('Location: index.php?url=tipos_documento/edit&id=' . $id);
+                exit;
+            }
+        }
+    }
+
+    public function delete() {
+        $id = $_GET['id'] ?? null;
+        if ($id) {
+            $db = Database::getInstance()->getConnection();
+            try {
+                $stmt = $db->prepare("CALL sp_delete_tipo_documento(?)");
+                $stmt->execute([$id]);
+            } catch (PDOException $e) {
+                $_SESSION['error_message'] = "No se puede eliminar el tipo de documento. Es posible que esté en uso.";
+            }
+        }
+        header('Location: index.php?url=tipos_documento');
+        exit;
+    }
+}
+?>

--- a/src/views/alumnos/create.php
+++ b/src/views/alumnos/create.php
@@ -46,10 +46,22 @@ unset($_SESSION['form_data']);
         </div>
         <div class="form-row">
             <div class="form-group">
-                <label for="documento_identidad">Documento de Identidad</label>
-                <input type="text" id="documento_identidad" name="documento_identidad" value="<?php echo htmlspecialchars($form_data['documento_identidad'] ?? ''); ?>" maxlength="8" pattern="[0-9]{8}" title="El DNI debe contener 8 dígitos numéricos.">
+                <label for="id_tipo_documento">Tipo de Documento</label>
+                <select id="id_tipo_documento" name="id_tipo_documento" required>
+                    <?php foreach ($tipos_documento as $tipo): ?>
+                        <option value="<?php echo htmlspecialchars($tipo['id']); ?>" data-longitud="<?php echo htmlspecialchars($tipo['longitud']); ?>" <?php echo (isset($form_data['id_tipo_documento']) && $form_data['id_tipo_documento'] == $tipo['id']) ? 'selected' : ''; ?>>
+                            <?php echo htmlspecialchars($tipo['descripcion']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="documento_identidad">Número de Documento</label>
+                <input type="text" id="documento_identidad" name="documento_identidad" value="<?php echo htmlspecialchars($form_data['documento_identidad'] ?? ''); ?>" required>
                 <div id="dni-error" class="error-text" style="display: none;"></div>
             </div>
+        </div>
+        <div class="form-row">
             <div class="form-group">
                 <label for="fecha_nacimiento">Fecha de Nacimiento</label>
                 <input type="date" id="fecha_nacimiento" name="fecha_nacimiento" value="<?php echo htmlspecialchars($form_data['fecha_nacimiento'] ?? ''); ?>">
@@ -101,87 +113,102 @@ require_once __DIR__ . '/../partials/footer.php';
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const form = document.querySelector('form');
-    const dniInput = document.getElementById('documento_identidad');
-    const dniError = document.getElementById('dni-error');
+    const tipoDocumentoSelect = document.getElementById('id_tipo_documento');
+    const documentoInput = document.getElementById('documento_identidad');
+    const documentoError = document.getElementById('dni-error');
     const submitButton = document.querySelector('button[type="submit"]');
 
-    let isDniDuplicate = false;
-    let isDniInvalid = false;
+    let isDocumentoDuplicate = false;
+    let isDocumentoInvalid = false;
 
-    function validateDniFormat() {
-        const dni = dniInput.value.trim();
-        // Permite que el campo esté vacío, la validación de 'required' se maneja en el HTML si es necesario
-        if (dni === '') {
-            dniError.style.display = 'none';
-            isDniInvalid = false;
+    function updateDocumentoValidation() {
+        const selectedOption = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex];
+        const longitud = selectedOption.getAttribute('data-longitud');
+
+        documentoInput.maxLength = longitud;
+        documentoInput.pattern = `^[0-9]{${longitud}}$`; // Asumiendo que todos son numéricos por ahora
+        documentoInput.title = `El documento debe contener ${longitud} dígitos.`;
+
+        // Disparar la validación del campo de documento inmediatamente
+        validateDocumentoFormat();
+    }
+
+    function validateDocumentoFormat() {
+        const documento = documentoInput.value.trim();
+        const longitud = documentoInput.maxLength;
+
+        if (documento === '') {
+            documentoError.style.display = 'none';
+            isDocumentoInvalid = false;
             updateSubmitButtonState();
             return;
         }
 
-        // Validar que solo contiene números y tiene 8 dígitos
-        if (!/^[0-9]{8}$/.test(dni)) {
-            dniError.textContent = 'El DNI debe contener 8 dígitos numéricos.';
-            dniError.style.display = 'block';
-            isDniInvalid = true;
+        const regex = new RegExp(`^[a-zA-Z0-9]{${longitud}}$`);
+        if (documento.length !== parseInt(longitud)) {
+            documentoError.textContent = `El número de documento debe tener exactamente ${longitud} caracteres.`;
+            documentoError.style.display = 'block';
+            isDocumentoInvalid = true;
         } else {
-            dniError.style.display = 'none';
-            isDniInvalid = false;
+            documentoError.style.display = 'none';
+            isDocumentoInvalid = false;
         }
         updateSubmitButtonState();
     }
 
-    function checkDniDuplication() {
-        const dni = dniInput.value.trim();
-        if (isDniInvalid || dni === '') {
-            isDniDuplicate = false;
+    function checkDocumentoDuplication() {
+        const documento = documentoInput.value.trim();
+        if (isDocumentoInvalid || documento === '') {
+            isDocumentoDuplicate = false;
             updateSubmitButtonState();
             return;
         }
 
-        fetch(`index.php?url=alumnos/checkDni&dni=${dni}`)
+        // El endpoint no cambia, la unicidad se sigue verificando en la misma columna
+        fetch(`index.php?url=alumnos/checkDni&dni=${documento}`)
             .then(response => response.json())
             .then(data => {
                 if (data.exists) {
-                    dniError.textContent = 'Este documento de identidad ya está registrado.';
-                    dniError.style.display = 'block';
-                    isDniDuplicate = true;
+                    documentoError.textContent = 'Este número de documento ya está registrado.';
+                    documentoError.style.display = 'block';
+                    isDocumentoDuplicate = true;
                 } else {
-                    // Si no hay duplicado, el mensaje de error (si existe) debe ser por formato
-                    if (!isDniInvalid) {
-                        dniError.style.display = 'none';
+                    if (!isDocumentoInvalid) {
+                        documentoError.style.display = 'none';
                     }
-                    isDniDuplicate = false;
+                    isDocumentoDuplicate = false;
                 }
                 updateSubmitButtonState();
             })
             .catch(error => {
-                console.error('Error al verificar el DNI:', error);
-                isDniDuplicate = false;
+                console.error('Error al verificar el documento:', error);
+                isDocumentoDuplicate = false;
                 updateSubmitButtonState();
             });
     }
 
     function updateSubmitButtonState() {
-        submitButton.disabled = isDniDuplicate || isDniInvalid;
+        submitButton.disabled = isDocumentoDuplicate || isDocumentoInvalid;
     }
 
-    // Validar formato mientras se escribe
-    dniInput.addEventListener('input', validateDniFormat);
+    // Event listeners
+    tipoDocumentoSelect.addEventListener('change', updateDocumentoValidation);
+    documentoInput.addEventListener('input', validateDocumentoFormat);
+    documentoInput.addEventListener('blur', checkDocumentoDuplication);
 
-    // Validar duplicados al salir del campo
-    dniInput.addEventListener('blur', checkDniDuplication);
+    // Initial validation setup on page load
+    updateDocumentoValidation();
 
     form.addEventListener('submit', function(event) {
-        // Re-validar todo al intentar enviar
-        validateDniFormat();
-        checkDniDuplication(); // Esto es asíncrono, pero la validación síncrona de abajo puede detener el envío
+        validateDocumentoFormat();
 
-        if (isDniInvalid) {
+        if (isDocumentoInvalid) {
             event.preventDefault();
-            alert('Por favor, corrija los errores en el formulario antes de guardar.\nEl DNI debe tener 8 dígitos numéricos.');
-        } else if (isDniDuplicate) {
+            const longitud = documentoInput.maxLength;
+            alert(`Por favor, corrija los errores. El número de documento debe tener ${longitud} caracteres.`);
+        } else if (isDocumentoDuplicate) {
             event.preventDefault();
-            alert('No se puede guardar el alumno porque el documento de identidad ya existe.');
+            alert('No se puede guardar el alumno porque el número de documento ya existe.');
         }
     });
 });

--- a/src/views/alumnos/edit.php
+++ b/src/views/alumnos/edit.php
@@ -43,10 +43,22 @@ $auth = new AuthController();
         </div>
         <div class="form-row">
             <div class="form-group">
-                <label for="documento_identidad">Documento de Identidad</label>
-                <input type="text" id="documento_identidad" name="documento_identidad" value="<?php echo htmlspecialchars($alumno['documento_identidad']); ?>" maxlength="8" pattern="[0-9]{8}" title="El DNI debe contener 8 dígitos numéricos.">
+                <label for="id_tipo_documento">Tipo de Documento</label>
+                <select id="id_tipo_documento" name="id_tipo_documento" required>
+                    <?php foreach ($tipos_documento as $tipo): ?>
+                        <option value="<?php echo htmlspecialchars($tipo['id']); ?>" data-longitud="<?php echo htmlspecialchars($tipo['longitud']); ?>" <?php echo ($alumno['id_tipo_documento'] == $tipo['id']) ? 'selected' : ''; ?>>
+                            <?php echo htmlspecialchars($tipo['descripcion']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="documento_identidad">Número de Documento</label>
+                <input type="text" id="documento_identidad" name="documento_identidad" value="<?php echo htmlspecialchars($alumno['documento_identidad']); ?>" required>
                 <div id="dni-error" class="error-text" style="display: none;"></div>
             </div>
+        </div>
+        <div class="form-row">
             <div class="form-group">
                 <label for="fecha_nacimiento">Fecha de Nacimiento</label>
                 <input type="date" id="fecha_nacimiento" name="fecha_nacimiento" value="<?php echo htmlspecialchars($alumno['fecha_nacimiento']); ?>">
@@ -98,83 +110,98 @@ require_once __DIR__ . '/../partials/footer.php';
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const form = document.querySelector('form');
-    const dniInput = document.getElementById('documento_identidad');
-    const dniError = document.getElementById('dni-error');
+    const tipoDocumentoSelect = document.getElementById('id_tipo_documento');
+    const documentoInput = document.getElementById('documento_identidad');
+    const documentoError = document.getElementById('dni-error');
     const submitButton = document.querySelector('button[type="submit"]');
     const studentId = document.querySelector('input[name="id_alumno"]').value;
-    const originalDni = "<?php echo htmlspecialchars($alumno['documento_identidad']); ?>";
+    const originalDocumento = "<?php echo htmlspecialchars($alumno['documento_identidad']); ?>";
 
-    let isDniDuplicate = false;
-    let isDniInvalid = false;
+    let isDocumentoDuplicate = false;
+    let isDocumentoInvalid = false;
 
-    function validateDniFormat() {
-        const dni = dniInput.value.trim();
-        if (dni === '') {
-            dniError.style.display = 'none';
-            isDniInvalid = false;
+    function updateDocumentoValidation() {
+        const selectedOption = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex];
+        const longitud = selectedOption.getAttribute('data-longitud');
+
+        documentoInput.maxLength = longitud;
+        documentoInput.title = `El documento debe contener ${longitud} caracteres.`;
+
+        validateDocumentoFormat();
+    }
+
+    function validateDocumentoFormat() {
+        const documento = documentoInput.value.trim();
+        const longitud = documentoInput.maxLength;
+
+        if (documento === '') {
+            documentoError.style.display = 'none';
+            isDocumentoInvalid = false;
             updateSubmitButtonState();
             return;
         }
 
-        if (!/^[0-9]{8}$/.test(dni)) {
-            dniError.textContent = 'El DNI debe contener 8 dígitos numéricos.';
-            dniError.style.display = 'block';
-            isDniInvalid = true;
+        if (documento.length !== parseInt(longitud)) {
+            documentoError.textContent = `El número de documento debe tener exactamente ${longitud} caracteres.`;
+            documentoError.style.display = 'block';
+            isDocumentoInvalid = true;
         } else {
-            dniError.style.display = 'none';
-            isDniInvalid = false;
+            documentoError.style.display = 'none';
+            isDocumentoInvalid = false;
         }
         updateSubmitButtonState();
     }
 
-    function checkDniDuplication() {
-        const dni = dniInput.value.trim();
-        if (isDniInvalid || dni === '' || dni === originalDni) {
-            isDniDuplicate = false;
+    function checkDocumentoDuplication() {
+        const documento = documentoInput.value.trim();
+        if (isDocumentoInvalid || documento === '' || documento === originalDocumento) {
+            isDocumentoDuplicate = false;
             updateSubmitButtonState();
             return;
         }
 
-        fetch(`index.php?url=alumnos/checkDni&dni=${dni}&id=${studentId}`)
+        fetch(`index.php?url=alumnos/checkDni&dni=${documento}&id=${studentId}`)
             .then(response => response.json())
             .then(data => {
                 if (data.exists) {
-                    dniError.textContent = 'Este documento de identidad ya está registrado.';
-                    dniError.style.display = 'block';
-                    isDniDuplicate = true;
+                    documentoError.textContent = 'Este número de documento ya está registrado.';
+                    documentoError.style.display = 'block';
+                    isDocumentoDuplicate = true;
                 } else {
-                    if (!isDniInvalid) {
-                        dniError.style.display = 'none';
+                    if (!isDocumentoInvalid) {
+                        documentoError.style.display = 'none';
                     }
-                    isDniDuplicate = false;
+                    isDocumentoDuplicate = false;
                 }
                 updateSubmitButtonState();
             })
             .catch(error => {
-                console.error('Error al verificar el DNI:', error);
-                isDniDuplicate = false;
+                console.error('Error al verificar el documento:', error);
+                isDocumentoDuplicate = false;
                 updateSubmitButtonState();
             });
     }
 
     function updateSubmitButtonState() {
-        submitButton.disabled = isDniDuplicate || isDniInvalid;
+        submitButton.disabled = isDocumentoDuplicate || isDocumentoInvalid;
     }
 
-    dniInput.addEventListener('input', validateDniFormat);
-    dniInput.addEventListener('blur', checkDniDuplication);
+    tipoDocumentoSelect.addEventListener('change', updateDocumentoValidation);
+    documentoInput.addEventListener('input', validateDocumentoFormat);
+    documentoInput.addEventListener('blur', checkDocumentoDuplication);
+
+    updateDocumentoValidation();
 
     form.addEventListener('submit', function(event) {
-        validateDniFormat();
-        // No llamamos a checkDniDuplication en submit para evitar el delay del fetch,
-        // la validación del blur ya debería haber seteado el estado.
+        validateDocumentoFormat();
 
-        if (isDniInvalid) {
+        if (isDocumentoInvalid) {
             event.preventDefault();
-            alert('Por favor, corrija los errores en el formulario antes de guardar.\nEl DNI debe tener 8 dígitos numéricos.');
-        } else if (isDniDuplicate) {
+            const longitud = documentoInput.maxLength;
+            alert(`Por favor, corrija los errores. El número de documento debe tener ${longitud} caracteres.`);
+        } else if (isDocumentoDuplicate) {
             event.preventDefault();
-            alert('No se puede actualizar el alumno porque el documento de identidad ya está en uso por otro alumno.');
+            alert('No se puede actualizar el alumno porque el número de documento ya está en uso por otro alumno.');
         }
     });
 });

--- a/src/views/matriculas/create.php
+++ b/src/views/matriculas/create.php
@@ -67,13 +67,25 @@ unset($_SESSION['form_data']);
                 </div>
                  <div class="form-row">
                     <div class="form-group">
-                        <label>Documento:</label>
-                        <input type="text" name="nuevo_alumno_documento" value="<?php echo htmlspecialchars($form_data['nuevo_alumno_documento'] ?? ''); ?>">
+                        <label>Tipo de Documento:</label>
+                        <select name="nuevo_alumno_id_tipo_documento" id="nuevo_alumno_id_tipo_documento" required>
+                            <?php foreach ($tipos_documento as $tipo): ?>
+                                <option value="<?php echo htmlspecialchars($tipo['id']); ?>" data-longitud="<?php echo htmlspecialchars($tipo['longitud']); ?>" <?php echo (isset($form_data['nuevo_alumno_id_tipo_documento']) && $form_data['nuevo_alumno_id_tipo_documento'] == $tipo['id']) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($tipo['descripcion']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Número de Documento:</label>
+                        <input type="text" name="nuevo_alumno_documento" id="nuevo_alumno_documento" value="<?php echo htmlspecialchars($form_data['nuevo_alumno_documento'] ?? ''); ?>" required>
                         <div class="error-text" id="nuevo-dni-error" style="display: none;"></div>
                     </div>
-                    <div class="form-group"><label>Teléfono:</label><input type="text" name="nuevo_alumno_telefono" value="<?php echo htmlspecialchars($form_data['nuevo_alumno_telefono'] ?? ''); ?>"></div>
                 </div>
-                 <div class="form-group"><label>Email:</label><input type="email" name="nuevo_alumno_email" value="<?php echo htmlspecialchars($form_data['nuevo_alumno_email'] ?? ''); ?>"></div>
+                <div class="form-row">
+                    <div class="form-group"><label>Teléfono:</label><input type="text" name="nuevo_alumno_telefono" value="<?php echo htmlspecialchars($form_data['nuevo_alumno_telefono'] ?? ''); ?>"></div>
+                    <div class="form-group"><label>Email:</label><input type="email" name="nuevo_alumno_email" value="<?php echo htmlspecialchars($form_data['nuevo_alumno_email'] ?? ''); ?>"></div>
+                </div>
             </div>
         </div>
 
@@ -429,60 +441,70 @@ document.getElementById('form-matricula').addEventListener('submit', function(ev
 });
 
 // DNI validation for new student
-const nuevoDniInput = document.querySelector('[name="nuevo_alumno_documento"]');
-const nuevoDniError = document.getElementById('nuevo-dni-error');
+const nuevoTipoDocumentoSelect = document.getElementById('nuevo_alumno_id_tipo_documento');
+const nuevoDocumentoInput = document.getElementById('nuevo_alumno_documento');
+const nuevoDocumentoError = document.getElementById('nuevo-dni-error');
 const mainForm = document.getElementById('form-matricula');
 const submitButton = document.querySelector('#form-matricula button[type="submit"]');
 
-let isNuevoDniDuplicate = false;
-let isNuevoDniInvalid = false;
+let isNuevoDocumentoDuplicate = false;
+let isNuevoDocumentoInvalid = false;
 
-function validateNuevoDniFormat() {
-    const dni = nuevoDniInput.value.trim();
-    if (dni === '') {
-        nuevoDniError.style.display = 'none';
-        isNuevoDniInvalid = false;
+function updateNuevoDocumentoValidation() {
+    const selectedOption = nuevoTipoDocumentoSelect.options[nuevoTipoDocumentoSelect.selectedIndex];
+    const longitud = selectedOption.getAttribute('data-longitud');
+    nuevoDocumentoInput.maxLength = longitud;
+    validateNuevoDocumentoFormat();
+}
+
+function validateNuevoDocumentoFormat() {
+    const documento = nuevoDocumentoInput.value.trim();
+    const longitud = nuevoDocumentoInput.maxLength;
+
+    if (documento === '') {
+        nuevoDocumentoError.style.display = 'none';
+        isNuevoDocumentoInvalid = false;
         updateSubmitButtonState();
         return;
     }
 
-    if (!/^[0-9]{8}$/.test(dni)) {
-        nuevoDniError.textContent = 'El DNI debe contener 8 dígitos numéricos.';
-        nuevoDniError.style.display = 'block';
-        isNuevoDniInvalid = true;
+    if (documento.length !== parseInt(longitud)) {
+        nuevoDocumentoError.textContent = `El número de documento debe tener ${longitud} caracteres.`;
+        nuevoDocumentoError.style.display = 'block';
+        isNuevoDocumentoInvalid = true;
     } else {
-        nuevoDniError.style.display = 'none';
-        isNuevoDniInvalid = false;
+        nuevoDocumentoError.style.display = 'none';
+        isNuevoDocumentoInvalid = false;
     }
     updateSubmitButtonState();
 }
 
-function checkNuevoDniDuplication() {
-    const dni = nuevoDniInput.value.trim();
-    if (isNuevoDniInvalid || dni === '') {
-        isNuevoDniDuplicate = false;
+function checkNuevoDocumentoDuplication() {
+    const documento = nuevoDocumentoInput.value.trim();
+    if (isNuevoDocumentoInvalid || documento === '') {
+        isNuevoDocumentoDuplicate = false;
         updateSubmitButtonState();
         return;
     }
 
-    fetch(`index.php?url=alumnos/checkDni&dni=${dni}`)
+    fetch(`index.php?url=alumnos/checkDni&dni=${documento}`)
         .then(response => response.json())
         .then(data => {
             if (data.exists) {
-                nuevoDniError.textContent = 'Este documento ya está registrado.';
-                nuevoDniError.style.display = 'block';
-                isNuevoDniDuplicate = true;
+                nuevoDocumentoError.textContent = 'Este número de documento ya está registrado.';
+                nuevoDocumentoError.style.display = 'block';
+                isNuevoDocumentoDuplicate = true;
             } else {
-                if (!isNuevoDniInvalid) {
-                    nuevoDniError.style.display = 'none';
+                if (!isNuevoDocumentoInvalid) {
+                    nuevoDocumentoError.style.display = 'none';
                 }
-                isNuevoDniDuplicate = false;
+                isNuevoDocumentoDuplicate = false;
             }
             updateSubmitButtonState();
         })
         .catch(error => {
-            console.error('Error al verificar el DNI:', error);
-            isNuevoDniDuplicate = false;
+            console.error('Error al verificar el documento:', error);
+            isNuevoDocumentoDuplicate = false;
             updateSubmitButtonState();
         });
 }
@@ -491,49 +513,41 @@ function updateSubmitButtonState() {
     const isAlumnoSelected = !!document.getElementById('id_alumno').value;
     const isNuevoAlumnoFormVisible = document.getElementById('nuevo-alumno-form').style.display === 'block';
 
-    // Si hay un alumno existente seleccionado, la validación del DNI del nuevo alumno no debe bloquear el submit.
-    if (isAlumnoSelected) {
+    if (isAlumnoSelected || !isNuevoAlumnoFormVisible) {
         submitButton.disabled = false;
         return;
     }
 
-    // Si el formulario de nuevo alumno no es visible, tampoco debe bloquear.
-    if (!isNuevoAlumnoFormVisible) {
-        submitButton.disabled = false;
-        return;
-    }
-
-    submitButton.disabled = isNuevoDniDuplicate || isNuevoDniInvalid;
+    submitButton.disabled = isNuevoDocumentoDuplicate || isNuevoDocumentoInvalid;
 }
 
+// Event listeners
+nuevoTipoDocumentoSelect.addEventListener('change', updateNuevoDocumentoValidation);
+nuevoDocumentoInput.addEventListener('input', validateNuevoDocumentoFormat);
+nuevoDocumentoInput.addEventListener('blur', checkNuevoDocumentoDuplication);
 
-// Event listeners for DNI validation
-nuevoDniInput.addEventListener('input', validateNuevoDniFormat);
-nuevoDniInput.addEventListener('blur', checkNuevoDniDuplication);
-
+// Initial validation
+updateNuevoDocumentoValidation();
 
 mainForm.addEventListener('submit', function(event) {
     const isAlumnoSelected = !!document.getElementById('id_alumno').value;
     const isNuevoAlumnoFormVisible = document.getElementById('nuevo-alumno-form').style.display === 'block';
 
-    // Solo validar DNI del nuevo alumno si no hay un alumno existente seleccionado Y el form de nuevo alumno está visible
     if (!isAlumnoSelected && isNuevoAlumnoFormVisible) {
-        validateNuevoDniFormat(); // Re-validar formato
-
-        if (isNuevoDniInvalid) {
+        validateNuevoDocumentoFormat();
+        if (isNuevoDocumentoInvalid) {
             event.preventDefault();
-            alert('Por favor, corrija los errores en el formulario antes de guardar.\nEl DNI del nuevo alumno debe tener 8 dígitos numéricos.');
-            return; // Detener aquí
+            alert(`Por favor, corrija los errores. El número de documento del nuevo alumno debe tener ${nuevoDocumentoInput.maxLength} caracteres.`);
+            return;
         }
-        if (isNuevoDniDuplicate) {
+        if (isNuevoDocumentoDuplicate) {
             event.preventDefault();
-            alert('No se puede registrar la matrícula porque el documento del nuevo alumno ya existe.');
-            return; // Detener aquí
+            alert('No se puede registrar la matrícula porque el número de documento del nuevo alumno ya existe.');
+            return;
         }
     }
 
-
-    if (!document.getElementById('id_alumno').value && !document.querySelector('[name="nuevo_alumno_nombres"]').value) {
+    if (!isAlumnoSelected && !document.querySelector('[name="nuevo_alumno_nombres"]').value) {
         alert('Por favor, seleccione un alumno existente o registre uno nuevo.');
         event.preventDefault();
     }

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -76,6 +76,7 @@ if (!defined('BASE_URL')) {
                     <div class="dropdown">
                         <a href="#">Configuración &#9662;</a>
                         <div class="dropdown-content">
+                            <a href="<?php echo BASE_URL; ?>index.php?url=tipos_documento">Tipo de Documento</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=tipos_piscina">Tipos de piscina</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=piscinas">Piscina</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=carriles">Carriles</a>

--- a/src/views/tipos_documento/create.php
+++ b/src/views/tipos_documento/create.php
@@ -1,0 +1,52 @@
+<?php
+require_once __DIR__ . '/../partials/header.php';
+require_once __DIR__ . '/../../controllers/AuthController.php';
+$auth = new AuthController();
+?>
+
+<style>
+/* Estilos para formularios (reutilizados) */
+.form-container { max-width: 600px; margin: 2rem auto; padding: 2rem; border: 1px solid #ddd; border-radius: 8px; }
+.form-group { margin-bottom: 1rem; }
+.form-group label { display: block; margin-bottom: 0.5rem; }
+.form-group input { width: 100%; padding: 0.5rem; border-radius: 4px; border: 1px solid #ccc; }
+.form-actions { margin-top: 1.5rem; text-align: right; }
+.btn { padding: 10px 15px; border: none; border-radius: 4px; color: white; text-decoration: none; cursor: pointer; }
+.btn-success { background-color: #5cb85c; }
+.btn-secondary { background-color: #6c757d; }
+</style>
+
+<div class="form-container">
+    <h2>Añadir Nuevo Tipo de Documento</h2>
+
+    <?php
+    if (isset($_SESSION['error_message'])) {
+        echo '<div class="alert alert-danger">' . htmlspecialchars($_SESSION['error_message']) . '</div>';
+        unset($_SESSION['error_message']);
+    }
+    ?>
+
+    <form action="index.php?url=tipos_documento/store" method="POST">
+        <input type="hidden" name="csrf_token" value="<?php echo $auth->getCsrfToken(); ?>">
+        <div class="form-group">
+            <label for="descripcion">Descripción</label>
+            <input type="text" id="descripcion" name="descripcion" required>
+        </div>
+        <div class="form-group">
+            <label for="longitud">Longitud (número de caracteres)</label>
+            <input type="number" id="longitud" name="longitud" required>
+        </div>
+        <div class="form-group">
+            <label for="sunat">Código SUNAT</label>
+            <input type="text" id="sunat" name="sunat" maxlength="3">
+        </div>
+        <div class="form-actions">
+            <a href="index.php?url=tipos_documento" class="btn btn-secondary">Cancelar</a>
+            <button type="submit" class="btn btn-success">Guardar</button>
+        </div>
+    </form>
+</div>
+
+<?php
+require_once __DIR__ . '/../partials/footer.php';
+?>

--- a/src/views/tipos_documento/edit.php
+++ b/src/views/tipos_documento/edit.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/../partials/header.php';
+require_once __DIR__ . '/../../controllers/AuthController.php';
+$auth = new AuthController();
+?>
+
+<style>
+/* Estilos para formularios (reutilizados) */
+.form-container { max-width: 600px; margin: 2rem auto; padding: 2rem; border: 1px solid #ddd; border-radius: 8px; }
+.form-group { margin-bottom: 1rem; }
+.form-group label { display: block; margin-bottom: 0.5rem; }
+.form-group input { width: 100%; padding: 0.5rem; border-radius: 4px; border: 1px solid #ccc; }
+.form-actions { margin-top: 1.5rem; text-align: right; }
+.btn { padding: 10px 15px; border: none; border-radius: 4px; color: white; text-decoration: none; cursor: pointer; }
+.btn-success { background-color: #5cb85c; }
+.btn-secondary { background-color: #6c757d; }
+</style>
+
+<div class="form-container">
+    <h2>Editar Tipo de Documento</h2>
+
+    <?php
+    if (isset($_SESSION['error_message'])) {
+        echo '<div class="alert alert-danger">' . htmlspecialchars($_SESSION['error_message']) . '</div>';
+        unset($_SESSION['error_message']);
+    }
+    ?>
+
+    <form action="index.php?url=tipos_documento/update" method="POST">
+        <input type="hidden" name="csrf_token" value="<?php echo $auth->getCsrfToken(); ?>">
+        <input type="hidden" name="id" value="<?php echo htmlspecialchars($tipo_documento['id']); ?>">
+        <div class="form-group">
+            <label for="descripcion">Descripción</label>
+            <input type="text" id="descripcion" name="descripcion" value="<?php echo htmlspecialchars($tipo_documento['descripcion']); ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="longitud">Longitud (número de caracteres)</label>
+            <input type="number" id="longitud" name="longitud" value="<?php echo htmlspecialchars($tipo_documento['longitud']); ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="sunat">Código SUNAT</label>
+            <input type="text" id="sunat" name="sunat" value="<?php echo htmlspecialchars($tipo_documento['sunat']); ?>" maxlength="3">
+        </div>
+        <div class="form-actions">
+            <a href="index.php?url=tipos_documento" class="btn btn-secondary">Cancelar</a>
+            <button type="submit" class="btn btn-success">Actualizar</button>
+        </div>
+    </form>
+</div>
+
+<?php
+require_once __DIR__ . '/../partials/footer.php';
+?>

--- a/src/views/tipos_documento/index.php
+++ b/src/views/tipos_documento/index.php
@@ -1,0 +1,52 @@
+<?php
+require_once __DIR__ . '/../partials/header.php';
+?>
+
+<div class="container">
+    <h2>Mantenimiento de Tipos de Documento</h2>
+    <p>Aquí puede gestionar los tipos de documento de identidad utilizados en el sistema.</p>
+    <a href="index.php?url=tipos_documento/create" class="btn btn-success mb-3">Añadir Nuevo Tipo</a>
+
+    <?php
+    if (isset($_SESSION['error_message'])) {
+        echo '<div class="alert alert-danger">' . htmlspecialchars($_SESSION['error_message']) . '</div>';
+        unset($_SESSION['error_message']);
+    }
+    ?>
+
+    <table class="table table-bordered table-striped">
+        <thead class="thead-dark">
+            <tr>
+                <th>ID</th>
+                <th>Descripción</th>
+                <th>Longitud</th>
+                <th>Código SUNAT</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (empty($tipos_documento)): ?>
+                <tr>
+                    <td colspan="5" class="text-center">No se encontraron tipos de documento.</td>
+                </tr>
+            <?php else: ?>
+                <?php foreach ($tipos_documento as $tipo): ?>
+                    <tr>
+                        <td><?php echo htmlspecialchars($tipo['id']); ?></td>
+                        <td><?php echo htmlspecialchars($tipo['descripcion']); ?></td>
+                        <td><?php echo htmlspecialchars($tipo['longitud']); ?></td>
+                        <td><?php echo htmlspecialchars($tipo['sunat']); ?></td>
+                        <td>
+                            <a href="index.php?url=tipos_documento/edit&id=<?php echo $tipo['id']; ?>" class="btn btn-primary btn-sm">Editar</a>
+                            <a href="index.php?url=tipos_documento/delete&id=<?php echo $tipo['id']; ?>" class="btn btn-danger btn-sm" onclick="return confirm('¿Está seguro de que desea eliminar este tipo de documento?');">Eliminar</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+
+<?php
+require_once __DIR__ . '/../partials/footer.php';
+?>


### PR DESCRIPTION
This commit introduces a new feature to manage document types (e.g., DNI, RUC, Passport) and integrates it into the student forms.

- A new table `tipos_documento` and corresponding CRUD stored procedures have been created.
- The `alumnos` table is altered to include `id_tipo_documento`.
- A new controller and views are added for the 'Tipo de Documento' maintenance screen.
- A link is added to the 'Configuración' menu.
- The student creation/editing forms are updated with a dropdown for document type.
- JavaScript is added to dynamically validate the document number's length based on the selected type.
- Backend controllers (`AlumnoController`, `MatriculaController`) and stored procedures are updated to handle the new field.