### PR TITLE
feat: Add document type maintenance and fix routing

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,6 +13,7 @@ require_once '../src/controllers/AuthController.php';
 require_once '../src/controllers/AlumnoController.php';
 require_once '../src/controllers/ProfesorController.php';
 require_once '../src/controllers/CursoController.php';
+require_once '../src/controllers/TipoDocumentoController.php';
 require_once '../src/controllers/TipoPiscinaController.php';
 require_once '../src/controllers/PiscinaController.php';
 require_once '../src/controllers/CarrilController.php';
@@ -78,6 +79,21 @@ switch ($route) {
             case 'search': $alumnoController->search(); break;
             case 'checkDni': $alumnoController->checkDni(); break;
             default: http_response_code(404); echo "<h1>404 - Acción no encontrada en Alumnos</h1>"; break;
+        }
+        break;
+
+    // Rutas de Tipos de Documento
+    case 'tipos_documento':
+        $tipoDocumentoController = new TipoDocumentoController();
+        $action = $parts[1] ?? 'index';
+        switch ($action) {
+            case 'index': $tipoDocumentoController->index(); break;
+            case 'create': $tipoDocumentoController->create(); break;
+            case 'store': $tipoDocumentoController->store(); break;
+            case 'edit': $tipoDocumentoController->edit(); break;
+            case 'update': $tipoDocumentoController->update(); break;
+            case 'delete': $tipoDocumentoController->delete(); break;
+            default: http_response_code(404); echo "<h1>404 - Acción no encontrada en Tipos de Documento</h1>"; break;
         }
         break;
 


### PR DESCRIPTION
This commit introduces a new feature to manage document types and integrates it into the student forms.

It also fixes a 404 error for the new maintenance screen by registering the `TipoDocumentoController` in the main router.

- A new table `tipos_documento` and corresponding CRUD stored procedures have been created.
- The `alumnos` table is altered to include `id_tipo_documento`.
- A new controller and views are added for the 'Tipo de Documento' maintenance screen.
- The student creation/editing forms are updated with a dropdown for document type and dynamic validation JavaScript.
- The router in `public/index.php` is updated to include the new controller routes.