### PR TITLE
refactor: Rename 'Monitor' menu item

### DIFF
--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -90,7 +90,7 @@ if (!defined('BASE_URL')) {
                     <div class="dropdown">
                         <a href="#">Operaciones &#9662;</a>
                         <div class="dropdown-content">
-                            <a href="<?php echo BASE_URL; ?>index.php?url=dashboard">Monitor</a>
+                            <a href="<?php echo BASE_URL; ?>index.php?url=dashboard">Panel de Control</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=alumnos">Clientes</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=profesores">Profesores</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=matriculas">Matriculas</a>


### PR DESCRIPTION
Changes the text for the 'Monitor' link in the 'Operaciones' dropdown to 'Panel de Control'.