### PR TITLE
refactor: Rename 'Inicio' menu item

### DIFF
--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -70,7 +70,7 @@ if (!defined('BASE_URL')) {
             <h1><a href="<?php echo BASE_URL; ?>index.php?url=inicio">NataciónSys</a></h1>
             <div class="nav-links">
                 <?php if (isset($_SESSION['user_id'])): ?>
-                    <a href="<?php echo BASE_URL; ?>index.php?url=inicio">Inicio</a>
+                    <a href="<?php echo BASE_URL; ?>index.php?url=inicio">Panel</a>
 
                     <div class="dropdown">
                         <a href="#">Configuración &#9662;</a>


### PR DESCRIPTION
Changes the text for the 'Inicio' link in the main navigation bar to 'Panel'.