### PR TITLE
fix: Correct arguments for sp_get_all_piscinas call

### DIFF
--- a/src/controllers/CarrilController.php
+++ b/src/controllers/CarrilController.php
@@ -23,8 +23,8 @@ class CarrilController {
     public function create() {
         $db = Database::getInstance()->getConnection();
         // Fetch pools for the dropdown
-        $stmt = $db->prepare("CALL sp_get_all_piscinas()");
-        $stmt->execute();
+        $stmt = $db->prepare("CALL sp_get_all_piscinas(?)");
+        $stmt->execute(['']);
         $piscinas = $stmt->fetchAll(PDO::FETCH_ASSOC);
         require_once __DIR__ . '/../views/carriles/create.php';
     }
@@ -56,8 +56,8 @@ class CarrilController {
 
         if ($carril) {
             // Fetch all pools for the dropdown
-            $stmt_piscinas = $db->prepare("CALL sp_get_all_piscinas()");
-            $stmt_piscinas->execute();
+            $stmt_piscinas = $db->prepare("CALL sp_get_all_piscinas(?)");
+            $stmt_piscinas->execute(['']);
             $piscinas = $stmt_piscinas->fetchAll(PDO::FETCH_ASSOC);
             require_once __DIR__ . '/../views/carriles/edit.php';
         } else {


### PR DESCRIPTION
- Modifies `CarrilController.php`.
- Updates the `create()` and `edit()` methods to pass an empty string argument to the `execute()` call for the `sp_get_all_piscinas` stored procedure.
- This resolves a fatal PDOException caused by an incorrect number of arguments being passed to the procedure.