### PR TITLE
refactor: Rename 'Piscina' to 'Area' and 'Carril' to 'Sub Area'

### DIFF
--- a/src/views/horarios/create.php
+++ b/src/views/horarios/create.php
@@ -58,12 +58,12 @@ $auth = new AuthController();
         </div>
         <div class="form-row">
             <div class="form-group">
-                <label for="id_carril">Piscina y Carril</label>
+                <label for="id_carril">Area y Sub Area</label>
                 <select id="id_carril" name="id_carril" required>
-                    <option value="">Seleccione un carril</option>
+                    <option value="">Seleccione una sub area</option>
                     <?php foreach ($carriles as $carril): ?>
                         <option value="<?php echo htmlspecialchars($carril['id_carril']); ?>" <?php echo (isset($form_data['id_carril']) && $form_data['id_carril'] == $carril['id_carril']) ? 'selected' : ''; ?>>
-                            <?php echo htmlspecialchars($carril['piscina_nombre'] . ' - Carril ' . $carril['numero_carril']); ?>
+                            <?php echo htmlspecialchars($carril['piscina_nombre'] . ' - Sub Area ' . $carril['numero_carril']); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/src/views/horarios/edit.php
+++ b/src/views/horarios/edit.php
@@ -58,11 +58,11 @@ $auth = new AuthController();
         </div>
         <div class="form-row">
             <div class="form-group">
-                <label for="id_carril">Piscina y Carril</label>
+                <label for="id_carril">Area y Sub Area</label>
                 <select id="id_carril" name="id_carril" required>
                     <?php foreach ($carriles as $carril): ?>
                         <option value="<?php echo htmlspecialchars($carril['id_carril']); ?>" <?php echo ($form_data['id_carril'] == $carril['id_carril']) ? 'selected' : ''; ?>>
-                            <?php echo htmlspecialchars($carril['piscina_nombre'] . ' - Carril ' . $carril['numero_carril']); ?>
+                            <?php echo htmlspecialchars($carril['piscina_nombre'] . ' - Sub Area ' . $carril['numero_carril']); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>


### PR DESCRIPTION
Replaces user-facing text for 'Piscina' and related terms with 'Area' and 'Sub Area' for consistency with business domain terminology.

- Updates main menu text.
- Updates titles, labels, and buttons in the `piscinas` views.
- Updates titles, labels, and buttons in the `carriles` views.
- Updates titles, labels, and buttons in the `tipos_piscina` views.
- Updates labels in the `horarios` create and edit views.