### PR TITLE
refactor: Rename 'Piscina' to 'Area' and 'Carril' to 'Sub Area'

### DIFF
--- a/src/views/horarios/index.php
+++ b/src/views/horarios/index.php
@@ -45,7 +45,7 @@ require_once __DIR__ . '/../partials/header.php';
                 <th>ID</th>
                 <th>Curso</th>
                 <th>Profesor</th>
-                <th>Piscina y Carril</th>
+                <th>Area y Sub Area</th>
                 <th>Días</th>
                 <th>Horario</th>
                 <th>Vigencia Inicio</th>


### PR DESCRIPTION
Replaces user-facing text for 'Piscina' and related terms with 'Area' and 'Sub Area' for consistency with business domain terminology.

- Updates main menu text.
- Updates titles, labels, and buttons in the `piscinas` views.
- Updates titles, labels, and buttons in the `carriles` views.
- Updates titles, labels, and buttons in the `tipos_piscina` views.
- Updates labels and headers in the `horarios` views.