### PR TITLE
refactor: Rename 'Tipo de Profesor' to 'Tipo de Curso'

### DIFF
--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -80,7 +80,7 @@ if (!defined('BASE_URL')) {
                             <a href="<?php echo BASE_URL; ?>index.php?url=carriles">Sub Area</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=formas_pago">Forma de pago</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=tipos_documento">Tipo de Documento</a>
-                            <a href="<?php echo BASE_URL; ?>index.php?url=tipos_profesor">Tipo de Profesor</a>
+                            <a href="<?php echo BASE_URL; ?>index.php?url=tipos_profesor">Tipo de Curso</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=tipos_piscina">Tipo de Area</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=tipos_precio">Tipo de Precio</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=tipos_horario">Tipo de horario</a>

--- a/src/views/profesores/create.php
+++ b/src/views/profesores/create.php
@@ -39,7 +39,7 @@ $auth = new AuthController();
                 <input type="text" id="apellidos" name="apellidos" required>
             </div>
             <div class="form-group">
-                <label for="id_tipo_profesor">Tipo de Profesor</label>
+                <label for="id_tipo_profesor">Tipo de Curso</label>
                 <select id="id_tipo_profesor" name="id_tipo_profesor" required>
                     <option value="">Seleccione un tipo</option>
                     <?php foreach ($tipos_profesor as $tipo): ?>

--- a/src/views/profesores/edit.php
+++ b/src/views/profesores/edit.php
@@ -41,7 +41,7 @@ $auth = new AuthController();
                 <input type="text" id="apellidos" name="apellidos" value="<?php echo htmlspecialchars($profesor['apellidos']); ?>" required>
             </div>
             <div class="form-group">
-                <label for="id_tipo_profesor">Tipo de Profesor</label>
+                <label for="id_tipo_profesor">Tipo de Curso</label>
                 <select id="id_tipo_profesor" name="id_tipo_profesor" required>
                     <option value="">Seleccione un tipo</option>
                     <?php foreach ($tipos_profesor as $tipo): ?>

--- a/src/views/profesores/index.php
+++ b/src/views/profesores/index.php
@@ -47,7 +47,7 @@ require_once __DIR__ . '/../partials/header.php';
                 <th>ID</th>
                 <th>Nombres</th>
                 <th>Apellidos</th>
-                <th>Tipo de Profesor</th>
+                <th>Tipo de Curso</th>
                 <th>Email</th>
                 <th>Teléfono</th>
                 <th>Estado</th>

--- a/src/views/tipos_profesor/create.php
+++ b/src/views/tipos_profesor/create.php
@@ -17,7 +17,7 @@ $auth = new AuthController();
 </style>
 
 <div class="form-container">
-    <h2>Añadir Nuevo Tipo de Profesor</h2>
+    <h2>Añadir Nuevo Tipo de Curso</h2>
 
     <?php
     if (isset($_SESSION['error_message'])) {

--- a/src/views/tipos_profesor/edit.php
+++ b/src/views/tipos_profesor/edit.php
@@ -17,7 +17,7 @@ $auth = new AuthController();
 </style>
 
 <div class="form-container">
-    <h2>Editar Tipo de Profesor</h2>
+    <h2>Editar Tipo de Curso</h2>
 
     <?php
     if (isset($_SESSION['error_message'])) {

--- a/src/views/tipos_profesor/index.php
+++ b/src/views/tipos_profesor/index.php
@@ -3,8 +3,8 @@ require_once __DIR__ . '/../partials/header.php';
 ?>
 
 <div class="container">
-    <h2>Gestión de Tipos de Profesor</h2>
-    <p>Aquí puede gestionar los tipos de profesor.</p>
+    <h2>Gestión de Tipos de Curso</h2>
+    <p>Aquí puede gestionar los tipos de curso.</p>
     <a href="index.php?url=tipos_profesor/create" class="btn btn-success mb-3">Añadir Nuevo Tipo</a>
 
     <?php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../partials/header.php';
         <tbody>
             <?php if (empty($items)): ?>
                 <tr>
-                    <td colspan="3" class="text-center">No se encontraron tipos de profesor.</td>
+                    <td colspan="3" class="text-center">No se encontraron tipos de curso.</td>
                 </tr>
             <?php else: ?>
                 <?php foreach ($items as $item): ?>
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../partials/header.php';
                         <td><?php echo htmlspecialchars($item['descripcion']); ?></td>
                         <td>
                             <a href="index.php?url=tipos_profesor/edit&id=<?php echo $item['id']; ?>" class="btn btn-primary btn-sm">Editar</a>
-                            <a href="index.php?url=tipos_profesor/delete&id=<?php echo $item['id']; ?>" class="btn btn-danger btn-sm" onclick="return confirm('¿Está seguro de que desea eliminar este tipo de profesor?');">Eliminar</a>
+                            <a href="index.php?url=tipos_profesor/delete&id=<?php echo $item['id']; ?>" class="btn btn-danger btn-sm" onclick="return confirm('¿Está seguro de que desea eliminar este tipo de curso?');">Eliminar</a>
                         </td>
                     </tr>
                 <?php endforeach; ?>


### PR DESCRIPTION
Replaces user-facing text for 'Tipo de Profesor' with 'Tipo de Curso' to correct the terminology as requested.

- Updates main menu text.
- Updates titles in the `tipos_profesor` views.
- Updates column header and form labels in the `profesores` views.