### PR TITLE
Fix: Matricula filter returns empty results on empty dates

### DIFF
--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -18,12 +18,15 @@ class MatriculaController {
         $db = Database::getInstance()->getConnection();
 
         // Valores por defecto para los filtros
+        $fecha_desde = !empty($_GET['fecha_inicio_desde']) ? $_GET['fecha_inicio_desde'] : null;
+        $fecha_hasta = !empty($_GET['fecha_inicio_hasta']) ? $_GET['fecha_inicio_hasta'] : null;
+
         $filters = [
             'id_alumno' => $_GET['id_alumno'] ?? 0,
             'id_curso' => $_GET['id_curso'] ?? 0,
             'id_tipo_curso' => $_GET['id_tipo_curso'] ?? 0,
-            'fecha_inicio_desde' => $_GET['fecha_inicio_desde'] ?? null,
-            'fecha_inicio_hasta' => $_GET['fecha_inicio_hasta'] ?? null,
+            'fecha_inicio_desde' => $fecha_desde,
+            'fecha_inicio_hasta' => $fecha_hasta,
             'estado' => $_GET['estado'] ?? 'Todos',
             'alumno_nombre' => '', // Nuevo
             'curso_nombre' => ''  // Nuevo


### PR DESCRIPTION
When filtering on the "Gestión de Matrículas" page, if the date fields were left empty and the "Filtrar" button was clicked, the grid would show no results.

This was caused by the controller (`MatriculaController.php`) passing empty strings ('') from the GET request to the stored procedure for the date parameters. The stored procedure (`sp_get_matriculas_filtradas`) is designed to ignore the date filter only when the parameter is NULL.

The fix modifies the controller to check if the date parameters from the GET request are empty. If they are, it converts them to `null` before executing the stored procedure. This ensures the query behaves as expected, matching the initial page load logic and correctly ignoring the date filter when it's not specified.