### PR TITLE
fix: Add missing menu item for multiple enrollment

### DIFF
--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -95,6 +95,7 @@ if (!defined('BASE_URL')) {
                             <a href="<?php echo BASE_URL; ?>index.php?url=alumnos">Clientes</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=profesores">Profesores</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=matriculas">Matriculas</a>
+                            <a href="<?php echo BASE_URL; ?>index.php?url=matricula_multiple">Matricula Multiple</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=horarios">Programar horarios</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=asistencias_profesor">Asistencia Profesores</a>
                             <a href="<?php echo BASE_URL; ?>index.php?url=asistencias_alumnos">Asistencia Clientes</a>


### PR DESCRIPTION
The previous commit for the multiple enrollment feature was missing the menu link in the header. This commit adds the 'Matricula Multiple' link to the 'Operaciones' dropdown menu.