### PR TITLE
fix: Correct arguments for sp_get_all_tipos_piscina

### DIFF
--- a/src/controllers/MatriculaMultipleController.php
+++ b/src/controllers/MatriculaMultipleController.php
@@ -18,8 +18,8 @@ class MatriculaMultipleController {
         $db = Database::getInstance()->getConnection();
 
         // Cargar tipos de área para el filtro
-        $stmt_tipos_area = $db->prepare("CALL sp_get_all_tipos_piscina()");
-        $stmt_tipos_area->execute();
+        $stmt_tipos_area = $db->prepare("CALL sp_get_all_tipos_piscina(?)");
+        $stmt_tipos_area->execute(['']);
         $tipos_area = $stmt_tipos_area->fetchAll(PDO::FETCH_ASSOC);
         $stmt_tipos_area->closeCursor();
 


### PR DESCRIPTION
This commit fixes a fatal error on the 'Matricula Multiple' page. The stored procedure 'sp_get_all_tipos_piscina' was being called with 0 arguments instead of the expected 1. The code is updated to pass an empty string as the search parameter, resolving the PDOException.