### PR TITLE
feat: Refactor multiple enrollment to include list and detail views

### DIFF
--- a/db/feature-matricula-groups-update.sql
+++ b/db/feature-matricula-groups-update.sql
@@ -1,0 +1,27 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_create_matricula`;
+
+CREATE PROCEDURE `sp_create_matricula`(
+    IN p_id_alumno INT,
+    IN p_id_horario INT,
+    IN p_id_usuario_admin INT,
+    IN p_fecha_inicio DATE,
+    IN p_fecha_fin DATE,
+    IN p_precio_base DECIMAL(10, 2),
+    IN p_descuento DECIMAL(10, 2),
+    IN p_id_forma_pago INT,
+    IN p_observaciones TEXT,
+    IN p_id_grupo_matricula INT -- Nuevo parámetro
+)
+BEGIN
+    DECLARE v_precio_final DECIMAL(10, 2);
+    SET v_precio_final = p_precio_base - p_descuento;
+
+    INSERT INTO matriculas (id_alumno, id_horario, id_usuario_admin, fecha_inicio, fecha_fin, precio_final, id_forma_pago, estado, observaciones, precio_base, descuento, id_grupo_matricula)
+    VALUES (p_id_alumno, p_id_horario, p_id_usuario_admin, p_fecha_inicio, p_fecha_fin, v_precio_final, p_id_forma_pago, 'activa', p_observaciones, p_precio_base, p_descuento, p_id_grupo_matricula);
+
+    SELECT LAST_INSERT_ID() as nueva_matricula_id;
+END$$
+
+DELIMITER ;

--- a/db/feature-matricula-groups.sql
+++ b/db/feature-matricula-groups.sql
@@ -1,0 +1,71 @@
+-- Nueva tabla para agrupar matrículas múltiples
+CREATE TABLE `matricula_grupos` (
+  `id_grupo_matricula` INT NOT NULL AUTO_INCREMENT,
+  `id_alumno` INT NOT NULL,
+  `fecha_creacion` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id_grupo_matricula`),
+  KEY `fk_matricula_grupos_alumnos_idx` (`id_alumno`),
+  CONSTRAINT `fk_matricula_grupos_alumnos` FOREIGN KEY (`id_alumno`) REFERENCES `alumnos` (`id_alumno`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Alterar la tabla de matrículas para añadir la referencia al grupo
+ALTER TABLE `matriculas`
+ADD COLUMN `id_grupo_matricula` INT NULL DEFAULT NULL AFTER `observaciones`,
+ADD INDEX `fk_matriculas_grupos_idx` (`id_grupo_matricula` ASC);
+
+ALTER TABLE `matriculas`
+ADD CONSTRAINT `fk_matriculas_grupos`
+  FOREIGN KEY (`id_grupo_matricula`)
+  REFERENCES `matricula_grupos` (`id_grupo_matricula`)
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;
+
+-- Stored procedure para obtener todos los grupos de matrículas
+DELIMITER $$
+
+CREATE PROCEDURE `sp_get_all_matricula_grupos`()
+BEGIN
+    SELECT
+        mg.id_grupo_matricula,
+        mg.fecha_creacion,
+        CONCAT(a.nombres, ' ', a.apellidos) AS nombre_cliente
+    FROM matricula_grupos mg
+    JOIN alumnos a ON mg.id_alumno = a.id_alumno
+    ORDER BY mg.fecha_creacion DESC;
+END$$
+
+DELIMITER ;
+
+-- Stored procedure para obtener el detalle de un grupo de matrícula
+DELIMITER $$
+
+CREATE PROCEDURE `sp_get_matricula_grupo_details`(
+    IN p_id_grupo_matricula INT
+)
+BEGIN
+    -- Primero, obtener la información del grupo y del alumno
+    SELECT
+        mg.id_grupo_matricula,
+        mg.fecha_creacion,
+        a.id_alumno,
+        CONCAT(a.nombres, ' ', a.apellidos) AS nombre_cliente
+    FROM matricula_grupos mg
+    JOIN alumnos a ON mg.id_alumno = a.id_alumno
+    WHERE mg.id_grupo_matricula = p_id_grupo_matricula;
+
+    -- Segundo, obtener todas las matrículas asociadas a ese grupo
+    SELECT
+        m.id_matricula,
+        c.nombre AS curso_nombre,
+        m.fecha_inicio,
+        m.fecha_fin,
+        m.precio_final,
+        m.estado
+    FROM matriculas m
+    JOIN horarios h ON m.id_horario = h.id_horario
+    JOIN cursos c ON h.id_curso = c.id_curso
+    WHERE m.id_grupo_matricula = p_id_grupo_matricula
+    ORDER BY c.nombre;
+END$$
+
+DELIMITER ;

--- a/db/feature-matricula-multiple.sql
+++ b/db/feature-matricula-multiple.sql
@@ -50,7 +50,8 @@ DELIMITER $$
 CREATE PROCEDURE `sp_create_matricula_multiple`(
     IN `p_id_alumno` INT,
     IN `p_id_usuario` INT,
-    IN `p_selected_schedules_json` TEXT -- JSON array of schedule IDs, e.g., "[1, 2, 3]"
+    IN `p_selected_schedules_json` TEXT, -- JSON array of schedule IDs, e.g., "[1, 2, 3]"
+    IN `p_id_grupo_matricula` INT
 )
 BEGIN
     DECLARE v_schedule_id INT;
@@ -92,7 +93,8 @@ BEGIN
                 v_precio_base,          -- Usar el precio base encontrado
                 0,                      -- descuento
                 1,                      -- id_forma_pago (default a 'Efectivo' o similar)
-                'Matrícula múltiple'    -- observaciones
+                'Matrícula múltiple',   -- observaciones
+                p_id_grupo_matricula    -- Nuevo ID de grupo
             );
 
             -- Get the ID of the matricula just created

--- a/public/index.php
+++ b/public/index.php
@@ -310,6 +310,8 @@ switch ($route) {
         $action = $parts[1] ?? 'index';
         switch($action) {
             case 'index': $matriculaMultipleController->index(); break;
+            case 'create': $matriculaMultipleController->create(); break;
+            case 'show': $matriculaMultipleController->show(); break;
             case 'getAvailableAreas': $matriculaMultipleController->getAvailableAreas(); break;
             case 'store': $matriculaMultipleController->store(); break;
             default: http_response_code(404); echo "<h1>404 - Acción no encontrada en Matrícula Múltiple</h1>"; break;

--- a/src/controllers/MatriculaMultipleController.php
+++ b/src/controllers/MatriculaMultipleController.php
@@ -12,9 +12,22 @@ class MatriculaMultipleController {
     }
 
     /**
-     * Muestra la página principal de Matrícula Múltiple.
+     * Muestra la lista de grupos de matrículas múltiples.
      */
     public function index() {
+        $db = Database::getInstance()->getConnection();
+        $stmt = $db->prepare("CALL sp_get_all_matricula_grupos()");
+        $stmt->execute();
+        $grupos = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+
+        require_once __DIR__ . '/../views/matriculas_multiples/index.php';
+    }
+
+    /**
+     * Muestra el formulario para crear una nueva matrícula múltiple.
+     */
+    public function create() {
         $db = Database::getInstance()->getConnection();
 
         // Cargar tipos de área para el filtro
@@ -29,9 +42,9 @@ class MatriculaMultipleController {
         $tipos_documento = $stmt_tipos_documento->fetchAll(PDO::FETCH_ASSOC);
         $stmt_tipos_documento->closeCursor();
 
-
-        require_once __DIR__ . '/../views/matriculas_multiples/index.php';
+        require_once __DIR__ . '/../views/matriculas_multiples/create.php';
     }
+
 
     /**
      * Manejador AJAX para obtener áreas/sub-áreas disponibles según filtros.
@@ -114,18 +127,23 @@ class MatriculaMultipleController {
                  throw new Exception("No se ha seleccionado ningún horario.");
             }
 
-            // Llamar al nuevo stored procedure
-            $stmt = $db->prepare("CALL sp_create_matricula_multiple(?, ?, ?)");
+            // 1. Crear el grupo de matrícula
+            $stmt_grupo = $db->prepare("INSERT INTO matricula_grupos (id_alumno) VALUES (?)");
+            $stmt_grupo->execute([$id_alumno]);
+            $id_grupo_matricula = $db->lastInsertId();
+
+            // 2. Llamar al stored procedure que crea las matrículas individuales
+            $stmt = $db->prepare("CALL sp_create_matricula_multiple(?, ?, ?, ?)");
             $stmt->execute([
                 $id_alumno,
                 $_SESSION['user_id'],
-                $selected_schedules_json
+                $selected_schedules_json,
+                $id_grupo_matricula
             ]);
 
             $db->commit();
-            // Idealmente, redirigir a una página de éxito o a la ficha del cliente.
-            // Por ahora, redirigimos a la lista de matrículas.
-            header('Location: index.php?url=matriculas');
+            // Redirigir a la lista de grupos de matrícula
+            header('Location: index.php?url=matricula_multiple');
             exit;
 
         } catch (Exception $e) {
@@ -133,9 +151,32 @@ class MatriculaMultipleController {
             // Guardar el error y los datos del formulario en la sesión para repoblar
             $_SESSION['error_message'] = "Error al crear la matrícula múltiple: " . $e->getMessage();
             $_SESSION['form_data'] = $_POST;
+            header('Location: index.php?url=matricula_multiple/create');
+            exit;
+        }
+    }
+
+    /**
+     * Muestra los detalles de un grupo de matrícula.
+     */
+    public function show() {
+        $id = $_GET['id'] ?? null;
+        if (!$id) {
             header('Location: index.php?url=matricula_multiple');
             exit;
         }
+
+        $db = Database::getInstance()->getConnection();
+        $stmt = $db->prepare("CALL sp_get_matricula_grupo_details(?)");
+        $stmt->execute([$id]);
+
+        $grupo = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->nextRowset(); // Moverse al siguiente conjunto de resultados
+        $matriculas = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $stmt->closeCursor();
+
+        require_once __DIR__ . '/../views/matriculas_multiples/show.php';
     }
 }
 ?>

--- a/src/views/matriculas_multiples/create.php
+++ b/src/views/matriculas_multiples/create.php
@@ -1,0 +1,284 @@
+<?php
+require_once __DIR__ . '/../partials/header.php';
+require_once __DIR__ . '/../../controllers/AuthController.php';
+$auth = new AuthController();
+
+?>
+
+<style>
+/* Estilos para el formulario de matrícula */
+.form-container { max-width: 1200px; margin: 2rem auto; padding: 2rem; border: 1px solid #ddd; border-radius: 8px; }
+.form-section { border-bottom: 1px solid #eee; padding-bottom: 1.5rem; margin-bottom: 1.5rem; }
+.form-row { display: flex; flex-wrap: wrap; margin: -0.75rem; }
+.form-group { flex: 1 1 300px; padding: 0.75rem; }
+.form-group label { display: block; margin-bottom: 0.5rem; font-weight: bold; }
+.form-group input, .form-group select, .form-group textarea { width: 100%; padding: 0.5rem; border-radius: 4px; border: 1px solid #ccc; }
+.form-actions { margin-top: 1rem; text-align: right; }
+.btn { padding: 10px 15px; border: none; border-radius: 4px; color: white; text-decoration: none; cursor: pointer; background-color: #007bff; }
+.btn-secondary { background-color: #6c757d; }
+.btn-success { background-color: #28a745; }
+.btn-primary { background-color: #007bff; }
+
+/* Estilos para búsqueda */
+.search-container { position: relative; }
+.search-results {
+    position: absolute;
+    background-color: white;
+    border: 1px solid #ccc;
+    width: 100%;
+    max-height: 200px;
+    overflow-y: auto;
+    z-index: 1000;
+}
+.search-result-item { padding: 10px; cursor: pointer; }
+.search-result-item:hover { background-color: #f0f0f0; }
+#nuevo-alumno-form { display: none; background-color: #f9f9f9; padding: 1rem; border-radius: 5px; margin-top: 1rem;}
+.error-text { color: red; font-size: 0.875em; margin-top: 0.25rem; }
+
+/* Estilos para los filtros y resultados */
+.filters-container { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; background-color: #f9f9f9; padding: 1rem; border-radius: 8px; margin-top: 1rem;}
+#available-areas-container { margin-top: 1.5rem; display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1rem; }
+.area-card { border: 1px solid #ccc; padding: 1rem; border-radius: 4px; cursor: pointer; }
+.area-card:hover { background-color: #f5f5f5; }
+.area-card.selected { border-color: #28a745; background-color: #eafaf1; }
+</style>
+
+<div class="form-container">
+    <h2>Matrícula Múltiple</h2>
+
+    <form id="form-matricula-multiple" action="index.php?url=matricula_multiple/store" method="POST">
+        <input type="hidden" name="csrf_token" value="<?php echo $auth->getCsrfToken(); ?>">
+
+        <!-- SECCIÓN 1: CLIENTE -->
+        <div class="form-section">
+            <h4>1. Seleccionar o Registrar Cliente</h4>
+            <div class="form-group search-container">
+                <label for="alumno_search">Buscar Cliente Existente</label>
+                <input type="text" id="alumno_search" class="form-control" placeholder="Escriba nombre, apellido o documento..." autocomplete="off">
+                <input type="hidden" id="id_alumno" name="id_alumno" required>
+                <div id="alumno-search-results" class="search-results"></div>
+                <small>Si el cliente no existe, regístrelo a continuación.</small>
+            </div>
+
+            <button type="button" id="btn-show-nuevo-alumno" class="btn btn-secondary">Registrar Nuevo Cliente</button>
+
+            <div id="nuevo-alumno-form">
+                <h5>Datos del Nuevo Cliente</h5>
+                <div class="form-row">
+                    <div class="form-group"><label>Nombres:</label><input type="text" name="nuevo_alumno_nombres"></div>
+                    <div class="form-group"><label>Apellidos:</label><input type="text" name="nuevo_alumno_apellidos"></div>
+                </div>
+                 <div class="form-row">
+                    <div class="form-group">
+                        <label>Tipo de Documento:</label>
+                        <select name="nuevo_alumno_id_tipo_documento" id="nuevo_alumno_id_tipo_documento">
+                            <?php foreach ($tipos_documento as $tipo): ?>
+                                <option value="<?php echo htmlspecialchars($tipo['id']); ?>" data-longitud="<?php echo htmlspecialchars($tipo['longitud']); ?>">
+                                    <?php echo htmlspecialchars($tipo['descripcion']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>Número de Documento:</label>
+                        <input type="text" name="nuevo_alumno_documento" id="nuevo_alumno_documento">
+                        <div class="error-text" id="nuevo-dni-error" style="display: none;"></div>
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group"><label>Teléfono:</label><input type="text" name="nuevo_alumno_telefono"></div>
+                    <div class="form-group"><label>Email:</label><input type="email" name="nuevo_alumno_email"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- SECCIÓN 2: FILTROS Y RESULTADOS -->
+        <div class="form-section">
+            <h4>2. Seleccionar Curso y Horario</h4>
+            <div class="filters-container">
+                <div class="form-group">
+                    <label for="filtro_tipo_area">Tipo de Area</label>
+                    <select id="filtro_tipo_area" name="filtro_tipo_area">
+                         <option value="0">Todos</option>
+                        <?php foreach ($tipos_area as $tipo): ?>
+                            <option value="<?php echo htmlspecialchars($tipo['id']); ?>">
+                                <?php echo htmlspecialchars($tipo['nombre']); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="filtro_fecha_inicio">Fecha Inicial</label>
+                    <input type="date" id="filtro_fecha_inicio" name="filtro_fecha_inicio">
+                </div>
+                <div class="form-group">
+                    <label for="filtro_fecha_fin">Fecha Final</label>
+                    <input type="date" id="filtro_fecha_fin" name="filtro_fecha_fin">
+                </div>
+                <div class="form-group">
+                    <label for="filtro_hora_inicio">Hora Inicial</label>
+                    <input type="time" id="filtro_hora_inicio" name="filtro_hora_inicio">
+                </div>
+                <div class="form-group">
+                    <label for="filtro_hora_fin">Hora Final</label>
+                    <input type="time" id="filtro_hora_fin" name="filtro_hora_fin">
+                </div>
+                <button type="button" id="btn-filtrar-areas" class="btn btn-primary">Filtrar</button>
+            </div>
+
+            <div id="available-areas-container">
+                <p>Use los filtros para buscar áreas y horarios disponibles.</p>
+            </div>
+             <input type="hidden" id="selected_schedules" name="selected_schedules" required>
+        </div>
+
+        <div class="form-actions">
+            <a href="index.php?url=inicio" class="btn btn-secondary">Cancelar</a>
+            <button type="submit" class="btn btn-success">Grabar Matrícula Múltiple</button>
+        </div>
+    </form>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Lógica para búsqueda de alumnos (copiada y adaptada)
+    const searchInput = document.getElementById('alumno_search');
+    const searchResults = document.getElementById('alumno-search-results');
+    const hiddenInputId = document.getElementById('id_alumno');
+    const nuevoAlumnoForm = document.getElementById('nuevo-alumno-form');
+
+    searchInput.addEventListener('keyup', function() {
+        const term = this.value;
+        hiddenInputId.value = '';
+        if (term.length < 2) {
+            searchResults.innerHTML = '';
+            return;
+        }
+        fetch(`index.php?url=alumnos/search&term=${term}`)
+            .then(response => response.json())
+            .then(data => {
+                searchResults.innerHTML = '';
+                data.forEach(alumno => {
+                    const item = document.createElement('div');
+                    item.className = 'search-result-item';
+                    item.textContent = `${alumno.nombres} ${alumno.apellidos} (${alumno.documento_identidad || 'N/D'})`;
+                    item.dataset.id = alumno.id_alumno;
+                    item.addEventListener('click', function() {
+                        searchInput.value = this.textContent;
+                        hiddenInputId.value = this.dataset.id;
+                        searchResults.innerHTML = '';
+                        nuevoAlumnoForm.style.display = 'none';
+                        document.querySelectorAll('#nuevo-alumno-form input').forEach(input => input.value = '');
+                    });
+                    searchResults.appendChild(item);
+                });
+            });
+    });
+
+    document.getElementById('btn-show-nuevo-alumno').addEventListener('click', function() {
+        nuevoAlumnoForm.style.display = 'block';
+        searchInput.value = '';
+        hiddenInputId.value = '';
+        searchResults.innerHTML = '';
+    });
+
+    // Lógica para el botón de filtrar
+    document.getElementById('btn-filtrar-areas').addEventListener('click', function() {
+        const id_tipo_area = document.getElementById('filtro_tipo_area').value;
+        const fecha_inicio = document.getElementById('filtro_fecha_inicio').value;
+        const fecha_fin = document.getElementById('filtro_fecha_fin').value;
+        const hora_inicio = document.getElementById('filtro_hora_inicio').value;
+        const hora_fin = document.getElementById('filtro_hora_fin').value;
+        const container = document.getElementById('available-areas-container');
+
+        if (!fecha_inicio || !fecha_fin || !hora_inicio || !hora_fin) {
+            alert('Por favor, complete todos los filtros de fecha y hora.');
+            return;
+        }
+
+        container.innerHTML = '<p>Buscando horarios disponibles...</p>';
+
+        const queryParams = new URLSearchParams({
+            id_tipo_area,
+            fecha_inicio,
+            fecha_fin,
+            hora_inicio,
+            hora_fin
+        });
+
+        fetch(`index.php?url=matricula_multiple/getAvailableAreas&${queryParams}`)
+            .then(response => response.json())
+            .then(data => {
+                container.innerHTML = '';
+                if (data.error) {
+                    container.innerHTML = `<p style="color: red;">${data.error}</p>`;
+                    return;
+                }
+                if (data.length === 0) {
+                    container.innerHTML = '<p>No se encontraron áreas disponibles con los criterios seleccionados.</p>';
+                    return;
+                }
+
+                data.forEach(area => {
+                    const card = document.createElement('div');
+                    card.className = 'area-card';
+                    card.dataset.scheduleId = area.id_horario;
+                    card.innerHTML = `
+                        <strong>Curso:</strong> ${area.curso_nombre}<br>
+                        <strong>Área:</strong> ${area.area_nombre} - ${area.sub_area_nombre}<br>
+                        <strong>Profesor:</strong> ${area.profesor_nombre}<br>
+                        <strong>Horario:</strong> ${area.hora_inicio} - ${area.hora_fin}<br>
+                        <strong>Días:</strong> ${area.tipo_horario_nombre}<br>
+                        <strong>Periodo del Horario:</strong> ${area.horario_fecha_inicio} al ${area.horario_fecha_fin}<br>
+                        <strong>Vacantes:</strong> ${area.vacantes_disponibles}
+                    `;
+                    container.appendChild(card);
+                });
+            })
+            .catch(error => {
+                container.innerHTML = `<p style="color: red;">Ocurrió un error al realizar la búsqueda.</p>`;
+                console.error('Error fetching available areas:', error);
+            });
+    });
+
+    // Lógica para seleccionar/deseleccionar tarjetas de área
+    const container = document.getElementById('available-areas-container');
+    const selectedSchedulesInput = document.getElementById('selected_schedules');
+    let selectedIds = [];
+
+    container.addEventListener('click', function(e) {
+        const card = e.target.closest('.area-card');
+        if (!card) return;
+
+        const scheduleId = card.dataset.scheduleId;
+        if (!scheduleId) return;
+
+        if (card.classList.contains('selected')) {
+            card.classList.remove('selected');
+            selectedIds = selectedIds.filter(id => id !== scheduleId);
+        } else {
+            card.classList.add('selected');
+            selectedIds.push(scheduleId);
+        }
+
+        selectedSchedulesInput.value = JSON.stringify(selectedIds);
+    });
+
+    // Validación del formulario
+    document.getElementById('form-matricula-multiple').addEventListener('submit', function(event) {
+        if (!document.getElementById('id_alumno').value && !document.querySelector('[name="nuevo_alumno_nombres"]').value) {
+            alert('Por favor, seleccione un cliente existente o registre uno nuevo.');
+            event.preventDefault();
+        }
+        if (selectedIds.length === 0) {
+            alert('Por favor, seleccione al menos un área/horario disponible.');
+            event.preventDefault();
+        }
+    });
+
+});
+</script>
+
+<?php
+require_once __DIR__ . '/../partials/footer.php';
+?>

--- a/src/views/matriculas_multiples/index.php
+++ b/src/views/matriculas_multiples/index.php
@@ -1,288 +1,42 @@
 <?php
 require_once __DIR__ . '/../partials/header.php';
-require_once __DIR__ . '/../../controllers/AuthController.php';
-$auth = new AuthController();
-
-// Esta página necesitará sus propios datos, como los tipos de área.
-// Por ahora, lo dejamos vacío.
-$tipos_area = []; // Se llenará desde el controlador
-$tipos_documento = []; // Se llenará desde el controlador
-
 ?>
 
-<style>
-/* Estilos para el formulario de matrícula */
-.form-container { max-width: 1200px; margin: 2rem auto; padding: 2rem; border: 1px solid #ddd; border-radius: 8px; }
-.form-section { border-bottom: 1px solid #eee; padding-bottom: 1.5rem; margin-bottom: 1.5rem; }
-.form-row { display: flex; flex-wrap: wrap; margin: -0.75rem; }
-.form-group { flex: 1 1 300px; padding: 0.75rem; }
-.form-group label { display: block; margin-bottom: 0.5rem; font-weight: bold; }
-.form-group input, .form-group select, .form-group textarea { width: 100%; padding: 0.5rem; border-radius: 4px; border: 1px solid #ccc; }
-.form-actions { margin-top: 1rem; text-align: right; }
-.btn { padding: 10px 15px; border: none; border-radius: 4px; color: white; text-decoration: none; cursor: pointer; background-color: #007bff; }
-.btn-secondary { background-color: #6c757d; }
-.btn-success { background-color: #28a745; }
-.btn-primary { background-color: #007bff; }
+<div class="container">
+    <h2>Matrículas Múltiples</h2>
+    <div class="actions">
+        <a href="index.php?url=matricula_multiple/create" class="btn btn-success">Nueva Matrícula Múltiple</a>
+    </div>
 
-/* Estilos para búsqueda */
-.search-container { position: relative; }
-.search-results {
-    position: absolute;
-    background-color: white;
-    border: 1px solid #ccc;
-    width: 100%;
-    max-height: 200px;
-    overflow-y: auto;
-    z-index: 1000;
-}
-.search-result-item { padding: 10px; cursor: pointer; }
-.search-result-item:hover { background-color: #f0f0f0; }
-#nuevo-alumno-form { display: none; background-color: #f9f9f9; padding: 1rem; border-radius: 5px; margin-top: 1rem;}
-.error-text { color: red; font-size: 0.875em; margin-top: 0.25rem; }
-
-/* Estilos para los filtros y resultados */
-.filters-container { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; background-color: #f9f9f9; padding: 1rem; border-radius: 8px; margin-top: 1rem;}
-#available-areas-container { margin-top: 1.5rem; display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1rem; }
-.area-card { border: 1px solid #ccc; padding: 1rem; border-radius: 4px; cursor: pointer; }
-.area-card:hover { background-color: #f5f5f5; }
-.area-card.selected { border-color: #28a745; background-color: #eafaf1; }
-</style>
-
-<div class="form-container">
-    <h2>Matrícula Múltiple</h2>
-
-    <form id="form-matricula-multiple" action="index.php?url=matricula_multiple/store" method="POST">
-        <input type="hidden" name="csrf_token" value="<?php echo $auth->getCsrfToken(); ?>">
-
-        <!-- SECCIÓN 1: CLIENTE -->
-        <div class="form-section">
-            <h4>1. Seleccionar o Registrar Cliente</h4>
-            <div class="form-group search-container">
-                <label for="alumno_search">Buscar Cliente Existente</label>
-                <input type="text" id="alumno_search" class="form-control" placeholder="Escriba nombre, apellido o documento..." autocomplete="off">
-                <input type="hidden" id="id_alumno" name="id_alumno" required>
-                <div id="alumno-search-results" class="search-results"></div>
-                <small>Si el cliente no existe, regístrelo a continuación.</small>
-            </div>
-
-            <button type="button" id="btn-show-nuevo-alumno" class="btn btn-secondary">Registrar Nuevo Cliente</button>
-
-            <div id="nuevo-alumno-form">
-                <h5>Datos del Nuevo Cliente</h5>
-                <div class="form-row">
-                    <div class="form-group"><label>Nombres:</label><input type="text" name="nuevo_alumno_nombres"></div>
-                    <div class="form-group"><label>Apellidos:</label><input type="text" name="nuevo_alumno_apellidos"></div>
-                </div>
-                 <div class="form-row">
-                    <div class="form-group">
-                        <label>Tipo de Documento:</label>
-                        <select name="nuevo_alumno_id_tipo_documento" id="nuevo_alumno_id_tipo_documento">
-                            <?php foreach ($tipos_documento as $tipo): ?>
-                                <option value="<?php echo htmlspecialchars($tipo['id']); ?>" data-longitud="<?php echo htmlspecialchars($tipo['longitud']); ?>">
-                                    <?php echo htmlspecialchars($tipo['descripcion']); ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label>Número de Documento:</label>
-                        <input type="text" name="nuevo_alumno_documento" id="nuevo_alumno_documento">
-                        <div class="error-text" id="nuevo-dni-error" style="display: none;"></div>
-                    </div>
-                </div>
-                <div class="form-row">
-                    <div class="form-group"><label>Teléfono:</label><input type="text" name="nuevo_alumno_telefono"></div>
-                    <div class="form-group"><label>Email:</label><input type="email" name="nuevo_alumno_email"></div>
-                </div>
-            </div>
-        </div>
-
-        <!-- SECCIÓN 2: FILTROS Y RESULTADOS -->
-        <div class="form-section">
-            <h4>2. Seleccionar Curso y Horario</h4>
-            <div class="filters-container">
-                <div class="form-group">
-                    <label for="filtro_tipo_area">Tipo de Area</label>
-                    <select id="filtro_tipo_area" name="filtro_tipo_area">
-                         <option value="0">Todos</option>
-                        <?php foreach ($tipos_area as $tipo): ?>
-                            <option value="<?php echo htmlspecialchars($tipo['id']); ?>">
-                                <?php echo htmlspecialchars($tipo['nombre']); ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label for="filtro_fecha_inicio">Fecha Inicial</label>
-                    <input type="date" id="filtro_fecha_inicio" name="filtro_fecha_inicio">
-                </div>
-                <div class="form-group">
-                    <label for="filtro_fecha_fin">Fecha Final</label>
-                    <input type="date" id="filtro_fecha_fin" name="filtro_fecha_fin">
-                </div>
-                <div class="form-group">
-                    <label for="filtro_hora_inicio">Hora Inicial</label>
-                    <input type="time" id="filtro_hora_inicio" name="filtro_hora_inicio">
-                </div>
-                <div class="form-group">
-                    <label for="filtro_hora_fin">Hora Final</label>
-                    <input type="time" id="filtro_hora_fin" name="filtro_hora_fin">
-                </div>
-                <button type="button" id="btn-filtrar-areas" class="btn btn-primary">Filtrar</button>
-            </div>
-
-            <div id="available-areas-container">
-                <p>Use los filtros para buscar áreas y horarios disponibles.</p>
-            </div>
-             <input type="hidden" id="selected_schedules" name="selected_schedules" required>
-        </div>
-
-        <div class="form-actions">
-            <a href="index.php?url=inicio" class="btn btn-secondary">Cancelar</a>
-            <button type="submit" class="btn btn-success">Grabar Matrícula Múltiple</button>
-        </div>
-    </form>
+    <table class="table-striped">
+        <thead>
+            <tr>
+                <th>ID Grupo</th>
+                <th>Cliente</th>
+                <th>Fecha de Creación</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (isset($grupos) && !empty($grupos)): ?>
+                <?php foreach ($grupos as $grupo): ?>
+                    <tr>
+                        <td><?php echo htmlspecialchars($grupo['id_grupo_matricula']); ?></td>
+                        <td><?php echo htmlspecialchars($grupo['nombre_cliente']); ?></td>
+                        <td><?php echo htmlspecialchars($grupo['fecha_creacion']); ?></td>
+                        <td>
+                            <a href="index.php?url=matricula_multiple/show&id=<?php echo htmlspecialchars($grupo['id_grupo_matricula']); ?>" class="btn btn-primary">Ver</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php else: ?>
+                <tr>
+                    <td colspan="4">No hay matrículas múltiples registradas.</td>
+                </tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Lógica para búsqueda de alumnos (copiada y adaptada)
-    const searchInput = document.getElementById('alumno_search');
-    const searchResults = document.getElementById('alumno-search-results');
-    const hiddenInputId = document.getElementById('id_alumno');
-    const nuevoAlumnoForm = document.getElementById('nuevo-alumno-form');
-
-    searchInput.addEventListener('keyup', function() {
-        const term = this.value;
-        hiddenInputId.value = '';
-        if (term.length < 2) {
-            searchResults.innerHTML = '';
-            return;
-        }
-        fetch(`index.php?url=alumnos/search&term=${term}`)
-            .then(response => response.json())
-            .then(data => {
-                searchResults.innerHTML = '';
-                data.forEach(alumno => {
-                    const item = document.createElement('div');
-                    item.className = 'search-result-item';
-                    item.textContent = `${alumno.nombres} ${alumno.apellidos} (${alumno.documento_identidad || 'N/D'})`;
-                    item.dataset.id = alumno.id_alumno;
-                    item.addEventListener('click', function() {
-                        searchInput.value = this.textContent;
-                        hiddenInputId.value = this.dataset.id;
-                        searchResults.innerHTML = '';
-                        nuevoAlumnoForm.style.display = 'none';
-                        document.querySelectorAll('#nuevo-alumno-form input').forEach(input => input.value = '');
-                    });
-                    searchResults.appendChild(item);
-                });
-            });
-    });
-
-    document.getElementById('btn-show-nuevo-alumno').addEventListener('click', function() {
-        nuevoAlumnoForm.style.display = 'block';
-        searchInput.value = '';
-        hiddenInputId.value = '';
-        searchResults.innerHTML = '';
-    });
-
-    // Lógica para el botón de filtrar
-    document.getElementById('btn-filtrar-areas').addEventListener('click', function() {
-        const id_tipo_area = document.getElementById('filtro_tipo_area').value;
-        const fecha_inicio = document.getElementById('filtro_fecha_inicio').value;
-        const fecha_fin = document.getElementById('filtro_fecha_fin').value;
-        const hora_inicio = document.getElementById('filtro_hora_inicio').value;
-        const hora_fin = document.getElementById('filtro_hora_fin').value;
-        const container = document.getElementById('available-areas-container');
-
-        if (!fecha_inicio || !fecha_fin || !hora_inicio || !hora_fin) {
-            alert('Por favor, complete todos los filtros de fecha y hora.');
-            return;
-        }
-
-        container.innerHTML = '<p>Buscando horarios disponibles...</p>';
-
-        const queryParams = new URLSearchParams({
-            id_tipo_area,
-            fecha_inicio,
-            fecha_fin,
-            hora_inicio,
-            hora_fin
-        });
-
-        fetch(`index.php?url=matricula_multiple/getAvailableAreas&${queryParams}`)
-            .then(response => response.json())
-            .then(data => {
-                container.innerHTML = '';
-                if (data.error) {
-                    container.innerHTML = `<p style="color: red;">${data.error}</p>`;
-                    return;
-                }
-                if (data.length === 0) {
-                    container.innerHTML = '<p>No se encontraron áreas disponibles con los criterios seleccionados.</p>';
-                    return;
-                }
-
-                data.forEach(area => {
-                    const card = document.createElement('div');
-                    card.className = 'area-card';
-                    card.dataset.scheduleId = area.id_horario;
-                    card.innerHTML = `
-                        <strong>Curso:</strong> ${area.curso_nombre}<br>
-                        <strong>Área:</strong> ${area.area_nombre} - ${area.sub_area_nombre}<br>
-                        <strong>Profesor:</strong> ${area.profesor_nombre}<br>
-                        <strong>Horario:</strong> ${area.hora_inicio} - ${area.hora_fin}<br>
-                        <strong>Días:</strong> ${area.tipo_horario_nombre}<br>
-                        <strong>Periodo del Horario:</strong> ${area.horario_fecha_inicio} al ${area.horario_fecha_fin}<br>
-                        <strong>Vacantes:</strong> ${area.vacantes_disponibles}
-                    `;
-                    container.appendChild(card);
-                });
-            })
-            .catch(error => {
-                container.innerHTML = `<p style="color: red;">Ocurrió un error al realizar la búsqueda.</p>`;
-                console.error('Error fetching available areas:', error);
-            });
-    });
-
-    // Lógica para seleccionar/deseleccionar tarjetas de área
-    const container = document.getElementById('available-areas-container');
-    const selectedSchedulesInput = document.getElementById('selected_schedules');
-    let selectedIds = [];
-
-    container.addEventListener('click', function(e) {
-        const card = e.target.closest('.area-card');
-        if (!card) return;
-
-        const scheduleId = card.dataset.scheduleId;
-        if (!scheduleId) return;
-
-        if (card.classList.contains('selected')) {
-            card.classList.remove('selected');
-            selectedIds = selectedIds.filter(id => id !== scheduleId);
-        } else {
-            card.classList.add('selected');
-            selectedIds.push(scheduleId);
-        }
-
-        selectedSchedulesInput.value = JSON.stringify(selectedIds);
-    });
-
-    // Validación del formulario
-    document.getElementById('form-matricula-multiple').addEventListener('submit', function(event) {
-        if (!document.getElementById('id_alumno').value && !document.querySelector('[name="nuevo_alumno_nombres"]').value) {
-            alert('Por favor, seleccione un cliente existente o registre uno nuevo.');
-            event.preventDefault();
-        }
-        if (selectedIds.length === 0) {
-            alert('Por favor, seleccione al menos un área/horario disponible.');
-            event.preventDefault();
-        }
-    });
-
-});
-</script>
 
 <?php
 require_once __DIR__ . '/../partials/footer.php';

--- a/src/views/matriculas_multiples/show.php
+++ b/src/views/matriculas_multiples/show.php
@@ -1,0 +1,59 @@
+<?php
+require_once __DIR__ . '/../partials/header.php';
+?>
+
+<div class="container">
+    <?php if (isset($grupo) && $grupo): ?>
+        <h2>Detalle del Grupo de Matrícula #<?php echo htmlspecialchars($grupo['id_grupo_matricula']); ?></h2>
+
+        <div class="info-section">
+            <p><strong>Cliente:</strong> <?php echo htmlspecialchars($grupo['nombre_cliente']); ?></p>
+            <p><strong>Fecha de Creación:</strong> <?php echo htmlspecialchars($grupo['fecha_creacion']); ?></p>
+        </div>
+
+        <h4>Matrículas Individuales en este Grupo:</h4>
+
+        <table class="table-striped">
+            <thead>
+                <tr>
+                    <th>ID Matrícula</th>
+                    <th>Curso</th>
+                    <th>Fecha Inicio</th>
+                    <th>Fecha Fin</th>
+                    <th>Precio Final</th>
+                    <th>Estado</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (isset($matriculas) && !empty($matriculas)): ?>
+                    <?php foreach ($matriculas as $matricula): ?>
+                        <tr>
+                            <td><?php echo htmlspecialchars($matricula['id_matricula']); ?></td>
+                            <td><?php echo htmlspecialchars($matricula['curso_nombre']); ?></td>
+                            <td><?php echo htmlspecialchars($matricula['fecha_inicio']); ?></td>
+                            <td><?php echo htmlspecialchars($matricula['fecha_fin']); ?></td>
+                            <td>S/ <?php echo htmlspecialchars(number_format($matricula['precio_final'], 2)); ?></td>
+                            <td><?php echo htmlspecialchars($matricula['estado']); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    <tr>
+                        <td colspan="6">No se encontraron matrículas en este grupo.</td>
+                    </tr>
+                <?php endif; ?>
+            </tbody>
+        </table>
+
+    <?php else: ?>
+        <h2>Grupo de Matrícula no encontrado</h2>
+        <p>El grupo de matrícula que busca no existe o fue eliminado.</p>
+    <?php endif; ?>
+
+    <div class="actions" style="margin-top: 2rem;">
+        <a href="index.php?url=matricula_multiple" class="btn btn-secondary">Volver a la Lista</a>
+    </div>
+</div>
+
+<?php
+require_once __DIR__ . '/../partials/footer.php';
+?>


### PR DESCRIPTION
This commit implements a major refactoring of the 'Matrícula Múltiple' feature based on user feedback.

- **New Database Structure**: Adds a `matricula_grupos` table to group multiple enrollments. The `matriculas` table is altered to link to this new table.
- **List and Detail Views**: The feature now starts with a list of all enrollment groups. A 'Ver' (View) button leads to a new detail page showing all enrollments within that group.
- **Refactored Flow**: The creation form is now accessed via a 'Nueva Matrícula Múltiple' button on the list page. The controller and router have been updated to support this new index -> create -> store -> show workflow.
- **Bug Fix**: Fixes an issue where the 'Tipo de Area' dropdown on the creation form was not being populated with data.