### PR TITLE
fix: Provide SQL script to update stored procedure

### DIFF
--- a/db/fix-sp-matricula-grupos-args.sql
+++ b/db/fix-sp-matricula-grupos-args.sql
@@ -1,0 +1,27 @@
+-- Corrige el procedimiento almacenado para aceptar filtros.
+-- Este script debe ejecutarse en la base de datos `natacion_bd`.
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_get_all_matricula_grupos`;
+
+CREATE PROCEDURE `sp_get_all_matricula_grupos`(
+    IN p_id_alumno INT,
+    IN p_fecha_desde DATE,
+    IN p_fecha_hasta DATE
+)
+BEGIN
+    SELECT
+        mg.id_grupo_matricula,
+        mg.fecha_creacion,
+        CONCAT(a.nombres, ' ', a.apellidos) AS nombre_cliente
+    FROM matricula_grupos mg
+    JOIN alumnos a ON mg.id_alumno = a.id_alumno
+    WHERE
+        (p_id_alumno = 0 OR mg.id_alumno = p_id_alumno)
+        AND (p_fecha_desde IS NULL OR mg.fecha_creacion >= p_fecha_desde)
+        AND (p_fecha_hasta IS NULL OR mg.fecha_creacion <= p_fecha_hasta)
+    ORDER BY mg.fecha_creacion DESC;
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
This commit adds a dedicated SQL script `db/fix-sp-matricula-grupos-args.sql` to fix a database schema mismatch.

The application code was updated to use filters for the multiple enrollment list, but the corresponding stored procedure `sp_get_all_matricula_grupos` was not updated in the user's environment. This script updates the stored procedure to accept the new filter parameters, resolving the 'Incorrect number of arguments' fatal error.