### PR TITLE
fix: Correct column name for area type filter

### DIFF
--- a/src/views/matriculas_multiples/create.php
+++ b/src/views/matriculas_multiples/create.php
@@ -100,7 +100,7 @@ $auth = new AuthController();
                     <select id="filtro_tipo_area" name="filtro_tipo_area">
                          <option value="0">Todos</option>
                         <?php foreach ($tipos_area as $tipo): ?>
-                            <option value="<?php echo htmlspecialchars($tipo['id']); ?>">
+                            <option value="<?php echo htmlspecialchars($tipo['id_tipo_piscina']); ?>">
                                 <?php echo htmlspecialchars($tipo['nombre']); ?>
                             </option>
                         <?php endforeach; ?>


### PR DESCRIPTION
This commit fixes a bug in the "Matrícula Múltiple" creation form where the "Tipo de Area" filter was not working correctly.

The dropdown was using the incorrect column name ('id' instead of 'id_tipo_piscina') for the option values, causing the filter to fail in the backend. The view file `src/views/matriculas_multiples/create.php` has been updated to use the correct column name.