### PR TITLE
fix: Add error reporting to single enrollment page

### DIFF
--- a/src/views/matriculas/create.php
+++ b/src/views/matriculas/create.php
@@ -44,6 +44,13 @@ unset($_SESSION['form_data']);
 <div class="form-container">
     <h2>Nueva Matrícula</h2>
 
+    <?php
+    if (isset($_SESSION['error_message'])) {
+        echo '<div style="padding: 1rem; margin-bottom: 1rem; border: 1px solid red; color: red; background-color: #fdd;">' . htmlspecialchars($_SESSION['error_message']) . '</div>';
+        unset($_SESSION['error_message']);
+    }
+    ?>
+
     <form id="form-matricula" action="index.php?url=matriculas/store" method="POST">
         <input type="hidden" name="csrf_token" value="<?php echo $auth->getCsrfToken(); ?>">
 


### PR DESCRIPTION
This commit adds an error display mechanism to the 'Nueva Matrícula' creation page (`create.php`).

A bug is preventing enrollments from being saved, but the error was not visible because the view was not displaying the `$_SESSION['error_message']` set by the controller's catch block.

This change adds the necessary code to display the session error message, which will allow for proper diagnosis of the underlying issue.