### PR TITLE
fix: Enhance calendar event display for text wrapping

### DIFF
--- a/src/controllers/CalendarioController.php
+++ b/src/controllers/CalendarioController.php
@@ -41,21 +41,17 @@ class CalendarioController {
             // Formatear para FullCalendar
             $calendar_events = [];
             foreach ($eventos as $evento) {
-                $formatted_time = date('h:i A', strtotime($evento['hora_inicio']));
-                $title = sprintf(
-                    "%s %s - %s\n%s: %s %s",
-                    $formatted_time,
-                    $evento['curso_nombre'],
-                    $evento['profesor_nombre'],
-                    $evento['area_nombre'],
-                    $evento['sub_area_descripcion'],
-                    $evento['sub_area_numero']
-                );
-
                 $calendar_events[] = [
-                    'title' => $title,
                     'start' => $evento['start_datetime'],
-                    'end' => $evento['end_datetime']
+                    'end' => $evento['end_datetime'],
+                    'extendedProps' => [
+                        'formatted_time' => date('h:i A', strtotime($evento['hora_inicio'])),
+                        'curso_nombre' => $evento['curso_nombre'],
+                        'profesor_nombre' => $evento['profesor_nombre'],
+                        'area_nombre' => $evento['area_nombre'],
+                        'sub_area_descripcion' => $evento['sub_area_descripcion'],
+                        'sub_area_numero' => $evento['sub_area_numero']
+                    ]
                 ];
             }
 

--- a/src/views/calendario/index.php
+++ b/src/views/calendario/index.php
@@ -11,6 +11,14 @@ require_once __DIR__ . '/../partials/header.php';
     max-width: 1100px;
     margin: 0 auto;
 }
+/* Forzar el ajuste de texto en los eventos del calendario */
+.fc-event-title {
+    white-space: normal !important;
+    overflow-wrap: break-word;
+}
+.fc-event-main-frame {
+    font-size: 0.8em;
+}
 </style>
 
 <div class="container">
@@ -33,7 +41,18 @@ document.addEventListener('DOMContentLoaded', function() {
             center: 'title',
             right: 'dayGridMonth,timeGridWeek,timeGridDay' // Opciones de vista
         },
-        events: 'index.php?url=calendario/getEventos'
+        events: 'index.php?url=calendario/getEventos',
+        eventContent: function(arg) {
+            let props = arg.event.extendedProps;
+            let titleHtml = `
+                <div class="fc-event-main-frame">
+                    <div style="font-weight: bold;">${props.formatted_time} - ${props.curso_nombre}</div>
+                    <div><small>${props.profesor_nombre}</small></div>
+                    <div><small>${props.area_nombre}: ${props.sub_area_descripcion} ${props.sub_area_numero}</small></div>
+                </div>
+            `;
+            return { html: titleHtml };
+        }
     });
 
     calendar.render();


### PR DESCRIPTION
This commit fixes a UI issue in the 'Calendario' view where long event titles were being truncated.

- The `getEventos()` method in `CalendarioController.php` has been updated to return structured JSON data with individual fields for the event details.
- The `index.php` view for the calendar now uses the `eventContent` hook in FullCalendar to render custom HTML for each event, allowing the text to wrap properly.
- Added CSS to support text wrapping within the event elements.