### PR TITLE
fix: Enhance calendar event display and add colors

### DIFF
--- a/db/final-update-script.sql
+++ b/db/final-update-script.sql
@@ -199,6 +199,7 @@ CREATE PROCEDURE `sp_get_clases_for_calendar`(
 BEGIN
     SELECT
         md.id_matricula_dia,
+        c.id_curso,
         c.nombre AS curso_nombre,
         h.hora_inicio,
         CONCAT(p.nombres, ' ', p.apellidos) AS profesor_nombre,

--- a/src/controllers/CalendarioController.php
+++ b/src/controllers/CalendarioController.php
@@ -38,12 +38,25 @@ class CalendarioController {
             $stmt->execute([$start_date, $end_date]);
             $eventos = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-            // Formatear para FullCalendar
+            // Formatear para FullCalendar y asignar colores
             $calendar_events = [];
+            $colors = ['#4e73df', '#1cc88a', '#36b9cc', '#f6c23e', '#e74a3b', '#858796', '#5a5c69'];
+            $course_colors = [];
+            $color_index = 0;
+
             foreach ($eventos as $evento) {
+                $id_curso = $evento['id_curso'];
+                if (!isset($course_colors[$id_curso])) {
+                    $course_colors[$id_curso] = $colors[$color_index % count($colors)];
+                    $color_index++;
+                }
+                $event_color = $course_colors[$id_curso];
+
                 $calendar_events[] = [
                     'start' => $evento['start_datetime'],
                     'end' => $evento['end_datetime'],
+                    'backgroundColor' => $event_color,
+                    'borderColor' => $event_color,
                     'extendedProps' => [
                         'formatted_time' => date('h:i A', strtotime($evento['hora_inicio'])),
                         'curso_nombre' => $evento['curso_nombre'],

--- a/src/views/calendario/index.php
+++ b/src/views/calendario/index.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../partials/header.php';
 ?>
 
 <style>
-/* Añadimos algunos estilos básicos para el calendario */
+/* Estilos para el calendario */
 .container {
     padding: 2rem;
 }
@@ -12,12 +12,19 @@ require_once __DIR__ . '/../partials/header.php';
     margin: 0 auto;
 }
 /* Forzar el ajuste de texto en los eventos del calendario */
-.fc-event-title {
+.fc-event-title, .fc-event-main-frame {
     white-space: normal !important;
-    overflow-wrap: break-word;
+    overflow-wrap: break-word !important;
+    font-size: 0.85em;
+    line-height: 1.3;
 }
-.fc-event-main-frame {
-    font-size: 0.8em;
+/* Permitir que las filas y los eventos crezcan */
+.fc-daygrid-day-frame {
+    min-height: 110px;
+}
+.fc-daygrid-event {
+    height: auto !important;
+    margin-bottom: 2px;
 }
 </style>
 


### PR DESCRIPTION
This commit implements two UI enhancements for the 'Calendario' page based on user feedback.

1.  **Event Colors**: Events are now color-coded based on their course ID. This helps visually distinguish different types of classes. The logic is handled in the `getEventos()` controller method.
2.  **Text Wrapping**: The view has been updated with more robust CSS to ensure long event titles wrap correctly within the calendar day cells, making all information visible. The `eventContent` hook is used to structure the event's HTML for better display.

The `sp_get_clases_for_calendar` stored procedure was also updated to provide the `id_curso` needed for the color-coding logic.