### PR TITLE
Fix: Resolve form submission freeze on single enrollment page

### DIFF
--- a/src/views/matriculas/create.php
+++ b/src/views/matriculas/create.php
@@ -221,10 +221,46 @@ const searchInput = document.getElementById('alumno_search');
 const searchResults = document.getElementById('alumno-search-results');
 const hiddenInputId = document.getElementById('id_alumno');
 const nuevoAlumnoForm = document.getElementById('nuevo-alumno-form');
+const nuevoAlumnoInputs = document.querySelectorAll('#nuevo-alumno-form input, #nuevo-alumno-form select');
+
+// Función para habilitar/deshabilitar el formulario de nuevo alumno
+function toggleNuevoAlumnoForm(enabled) {
+    if (enabled) {
+        nuevoAlumnoForm.style.display = 'block';
+        nuevoAlumnoInputs.forEach(input => {
+            input.disabled = false;
+            // Solo añadir 'required' a los campos que realmente lo son
+            if (input.name === 'nuevo_alumno_documento' || input.name === 'nuevo_alumno_id_tipo_documento') {
+                input.required = true;
+            }
+        });
+    } else {
+        nuevoAlumnoForm.style.display = 'none';
+        nuevoAlumnoInputs.forEach(input => {
+            input.disabled = true;
+            input.required = false;
+            input.value = ''; // Limpiar valores
+        });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Deshabilitar el formulario de nuevo alumno al cargar la página
+    // a menos que ya venga con datos de un error de servidor.
+    const hasNewStudentData = <?php echo !empty($form_data['nuevo_alumno_nombres']) ? 'true' : 'false'; ?>;
+    toggleNuevoAlumnoForm(hasNewStudentData);
+
+    // ... resto del código DOMContentLoaded
+    if (preselectedSchedule) {
+        // ... (código existente)
+    }
+});
+
 
 searchInput.addEventListener('keyup', function() {
     const term = this.value;
     hiddenInputId.value = '';
+    toggleNuevoAlumnoForm(false); // Deshabilitar al empezar a buscar
     if (term.length < 2) {
         searchResults.innerHTML = '';
         return;
@@ -242,8 +278,7 @@ searchInput.addEventListener('keyup', function() {
                     searchInput.value = this.textContent;
                     hiddenInputId.value = this.dataset.id;
                     searchResults.innerHTML = '';
-                    nuevoAlumnoForm.style.display = 'none';
-                    document.querySelectorAll('#nuevo-alumno-form input').forEach(input => input.value = '');
+                    toggleNuevoAlumnoForm(false); // Deshabilitar al seleccionar uno existente
                 });
                 searchResults.appendChild(item);
             });
@@ -251,10 +286,10 @@ searchInput.addEventListener('keyup', function() {
 });
 
 document.getElementById('btn-show-nuevo-alumno').addEventListener('click', function() {
-    nuevoAlumnoForm.style.display = 'block';
     searchInput.value = '';
     hiddenInputId.value = '';
     searchResults.innerHTML = '';
+    toggleNuevoAlumnoForm(true); // Habilitar al hacer clic en registrar nuevo
 });
 
 // Lógica para búsqueda de cursos


### PR DESCRIPTION
This commit provides the definitive fix for the critical bug on the 'Nueva Matrícula' page where the form would freeze and not submit.

The root cause was the browser attempting to run HTML5 validation on `required` fields within the 'Registrar Nuevo Cliente' sub-form, even when it was hidden (`display: none`). This caused a "not focusable" error, blocking the submission.

The fix implements robust JavaScript logic to dynamically add/remove the `disabled` attribute to the inputs of the sub-form. Disabled inputs are ignored by form validation, resolving the issue. The inputs are now only enabled and marked as required when the user explicitly clicks the button to register a new client.