### PR TITLE
fix: Correct single enrollment save and UI validation

### DIFF
--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -373,7 +373,7 @@ class MatriculaController {
                 }
 
                 // 1. Crear la matrícula (Lógica corregida)
-                $stmt_matricula = $db->prepare("CALL sp_create_matricula(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                $stmt_matricula = $db->prepare("CALL sp_create_matricula(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                 $stmt_matricula->execute([
                     $id_alumno,
                     $_POST['id_horario'],
@@ -383,7 +383,8 @@ class MatriculaController {
                     $_POST['precio_base'], // Se envía el precio base
                     $_POST['descuento'],
                     $_POST['id_forma_pago'],
-                    $_POST['observaciones']
+                    $_POST['observaciones'],
+                    null // id_grupo_matricula es null para matrículas individuales
                 ]);
                 $result = $stmt_matricula->fetch(PDO::FETCH_ASSOC);
                 $new_matricula_id = $result['nueva_matricula_id'];

--- a/src/views/matriculas/create.php
+++ b/src/views/matriculas/create.php
@@ -250,6 +250,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const hasNewStudentData = <?php echo !empty($form_data['nuevo_alumno_nombres']) ? 'true' : 'false'; ?>;
     toggleNuevoAlumnoForm(hasNewStudentData);
 
+    // Llamar a la validación inicial para establecer el maxlength correcto al cargar la página
+    updateNuevoDocumentoValidation();
+
     // ... resto del código DOMContentLoaded
     if (preselectedSchedule) {
         // ... (código existente)


### PR DESCRIPTION
This commit provides the definitive fix for the persistent bug on the "Nueva Matrícula" page.

1.  **Backend Fix**: The `store()` method in `MatriculaController.php` has been corrected to pass the 10th parameter (`id_grupo_matricula` as null) to the `sp_create_matricula` stored procedure, resolving the "Incorrect number of arguments" error.
2.  **Frontend Fix**: The JavaScript on the `create.php` view has been updated to correctly set the initial `maxlength` for the document number input field, resolving a minor UI validation bug.

These changes, combined with the `final-update-script.sql`, should restore all functionality.