### PR TITLE
refactor: Resubmit calendar color logic with trivial change

### DIFF
--- a/src/controllers/CalendarioController.php
+++ b/src/controllers/CalendarioController.php
@@ -40,7 +40,8 @@ class CalendarioController {
 
             // Formatear para FullCalendar y asignar colores pastel de forma determinista
             $calendar_events = [];
-            $pastel_colors = ['#a8d8ea', '#fce38a', '#eaffd0', '#f4b6c2', '#b39ddb', '#ffcc80', '#b2dfdb', '#ffAB91', '#c5e1a5'];
+            // Paleta de colores pastel actualizada para forzar el reenvío del cambio.
+            $pastel_colors = ['#a8d8ea', '#fce38a', '#eaffd0', '#f4b6c2', '#b39ddb', '#ffcc80', '#b2dfdb', '#ffAB91', '#c5e1a5', '#FDD835'];
 
             foreach ($eventos as $evento) {
                 $id_curso = $evento['id_curso'];


### PR DESCRIPTION
This commit resubmits the logic for assigning consistent, pastel colors to calendar events.

A trivial change was made to the color array to force a new commit, as the user reported the previous update was not being reflected in their local environment. The core logic remains the same: using a deterministic algorithm based on the course ID to assign colors.