### PR TITLE
fix: Provide final fix for calendar event coloring

### DIFF
--- a/db/fix-calendar-sp-final.sql
+++ b/db/fix-calendar-sp-final.sql
@@ -1,0 +1,40 @@
+-- =================================================================
+-- ARCHIVO DE ACTUALIZACIÓN FINAL PARA EL CALENDARIO (COLORES)
+-- =================================================================
+-- Este script actualiza el procedimiento almacenado del calendario
+-- para que devuelva el id_curso, necesario para la funcionalidad
+-- de colores consistentes por curso.
+-- Ejecute este script para asegurar que el calendario funcione
+-- con todas sus características.
+-- =================================================================
+
+DELIMITER $$
+DROP PROCEDURE IF EXISTS `sp_get_clases_for_calendar`;
+CREATE PROCEDURE `sp_get_clases_for_calendar`(
+    IN p_start_date DATE,
+    IN p_end_date DATE
+)
+BEGIN
+    SELECT
+        md.id_matricula_dia,
+        c.id_curso,
+        c.nombre AS curso_nombre,
+        h.hora_inicio,
+        CONCAT(p.nombres, ' ', p.apellidos) AS profesor_nombre,
+        pi.nombre AS area_nombre,
+        ca.descripcion AS sub_area_descripcion,
+        ca.numero_carril AS sub_area_numero,
+        CONCAT(md.fecha_clase, 'T', h.hora_inicio) AS start_datetime,
+        CONCAT(md.fecha_clase, 'T', h.hora_fin) AS end_datetime
+    FROM matricula_dias md
+    JOIN matriculas m ON md.id_matricula = m.id_matricula
+    JOIN horarios h ON m.id_horario = h.id_horario
+    JOIN cursos c ON h.id_curso = c.id_curso
+    JOIN profesores p ON h.id_profesor = p.id_profesor
+    JOIN carriles ca ON h.id_carril = ca.id_carril
+    JOIN piscinas pi ON ca.id_piscina = pi.id_piscina
+    WHERE
+        md.fecha_clase BETWEEN p_start_date AND p_end_date
+        AND m.estado IN ('activa', 'vigente');
+END$$
+DELIMITER ;

--- a/src/controllers/CalendarioController.php
+++ b/src/controllers/CalendarioController.php
@@ -54,7 +54,7 @@ class CalendarioController {
                 } else {
                     // Si no, usamos una lógica no determinista como fallback para al menos ver colores diferentes
                     if (!isset($course_colors[$evento['curso_nombre']])) {
-                        $course_colors[$evento['curso_nombre']] = $colors[$color_index % count($colors)];
+                        $course_colors[$evento['curso_nombre']] = $pastel_colors[$color_index % count($pastel_colors)];
                         $color_index++;
                     }
                     $event_color = $course_colors[$evento['curso_nombre']];


### PR DESCRIPTION
This commit provides a definitive fix for the calendar event coloring feature.

1.  **Controller Fix**: Corrects a bug in the fallback logic in `getEventos()` where an undefined variable was used, preventing colors from being displayed if the database procedure was out of date. The logic is now robust.
2.  **New SQL Script**: As requested by the user, a new, separate script `db/fix-calendar-sp-final.sql` is provided. This script contains the necessary update to the `sp_get_clases_for_calendar` procedure to enable consistent, deterministic coloring based on the course ID.

Running the new SQL script and applying this code change will ensure the calendar coloring works correctly and as intended.