### PR TITLE
fix: Simplify and fix calendar event display

### DIFF
--- a/src/controllers/CalendarioController.php
+++ b/src/controllers/CalendarioController.php
@@ -38,42 +38,30 @@ class CalendarioController {
             $stmt->execute([$start_date, $end_date]);
             $eventos = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-            // Formatear para FullCalendar y asignar colores pastel de forma robusta
             $calendar_events = [];
             $pastel_colors = ['#a8d8ea', '#fce38a', '#eaffd0', '#f4b6c2', '#b39ddb', '#ffcc80', '#b2dfdb', '#ffAB91', '#c5e1a5'];
-            $course_colors = [];
-            $color_index = 0;
 
             foreach ($eventos as $evento) {
-                // Lógica de color robusta
-                $event_color = $pastel_colors[0]; // Color por defecto
-                if (isset($evento['id_curso'])) {
-                    // Si el SP devuelve id_curso, usamos la lógica determinista (ideal)
-                    $id_curso = $evento['id_curso'];
-                    $event_color = $pastel_colors[$id_curso % count($pastel_colors)];
-                } else {
-                    // Si no, usamos una lógica no determinista como fallback para al menos ver colores diferentes
-                    if (!isset($course_colors[$evento['curso_nombre']])) {
-                        $course_colors[$evento['curso_nombre']] = $pastel_colors[$color_index % count($pastel_colors)];
-                        $color_index++;
-                    }
-                    $event_color = $course_colors[$evento['curso_nombre']];
-                }
+                // Asignación de color determinista
+                $event_color = $pastel_colors[$evento['id_curso'] % count($pastel_colors)];
+
+                // Crear el título directamente
+                $formatted_time = date('h:i A', strtotime($evento['hora_inicio']));
+                $title = sprintf(
+                    "%s %s\n%s\n%s",
+                    $formatted_time,
+                    $evento['curso_nombre'],
+                    $evento['profesor_nombre'],
+                    $evento['area_nombre'] . ': ' . $evento['sub_area_descripcion'] . ' ' . $evento['sub_area_numero']
+                );
 
                 $calendar_events[] = [
+                    'title' => $title,
                     'start' => $evento['start_datetime'],
                     'end' => $evento['end_datetime'],
                     'backgroundColor' => $event_color,
                     'borderColor' => $event_color,
-                    'textColor' => '#333333',
-                    'extendedProps' => [
-                        'formatted_time' => date('h:i A', strtotime($evento['hora_inicio'])),
-                        'curso_nombre' => $evento['curso_nombre'],
-                        'profesor_nombre' => $evento['profesor_nombre'],
-                        'area_nombre' => $evento['area_nombre'],
-                        'sub_area_descripcion' => $evento['sub_area_descripcion'],
-                        'sub_area_numero' => $evento['sub_area_numero']
-                    ]
+                    'textColor' => '#333333'
                 ];
             }
 

--- a/src/views/calendario/index.php
+++ b/src/views/calendario/index.php
@@ -12,19 +12,15 @@ require_once __DIR__ . '/../partials/header.php';
     margin: 0 auto;
 }
 /* Forzar el ajuste de texto en los eventos del calendario */
-.fc-event-title, .fc-event-main-frame {
-    white-space: normal !important;
-    overflow-wrap: break-word !important;
+.fc-event-title {
+    white-space: normal !important; /* Permite que el texto se ajuste en múltiples líneas */
+    overflow-wrap: break-word;
     font-size: 0.85em;
     line-height: 1.3;
 }
-/* Permitir que las filas y los eventos crezcan */
-.fc-daygrid-day-frame {
+/* Opcional: Dar un poco más de altura a las celdas para que quepa el texto */
+.fc .fc-daygrid-day-frame {
     min-height: 110px;
-}
-.fc-daygrid-event {
-    height: auto !important;
-    margin-bottom: 2px;
 }
 </style>
 
@@ -46,20 +42,11 @@ document.addEventListener('DOMContentLoaded', function() {
         headerToolbar: {
             left: 'prev,next today',
             center: 'title',
-            right: 'dayGridMonth,timeGridWeek,timeGridDay' // Opciones de vista
+            right: 'dayGridMonth,timeGridWeek,timeGridDay'
         },
-        events: 'index.php?url=calendario/getEventos',
-        eventContent: function(arg) {
-            let props = arg.event.extendedProps;
-            let titleHtml = `
-                <div class="fc-event-main-frame">
-                    <div style="font-weight: bold;">${props.formatted_time} - ${props.curso_nombre}</div>
-                    <div><small>${props.profesor_nombre}</small></div>
-                    <div><small>${props.area_nombre}: ${props.sub_area_descripcion} ${props.sub_area_numero}</small></div>
-                </div>
-            `;
-            return { html: titleHtml };
-        }
+        // El backend ahora envía el 'title' y los colores directamente.
+        // FullCalendar los usará por defecto.
+        events: 'index.php?url=calendario/getEventos'
     });
 
     calendar.render();


### PR DESCRIPTION
This commit provides a definitive fix for issues related to text-wrapping and color-coding on the 'Calendario' page.

The implementation has been simplified to improve reliability:
1.  The `getEventos()` method in `CalendarioController.php` now pre-formats the multi-line event title and passes the `backgroundColor` and `borderColor` properties directly in the main event object.
2.  The `eventContent` JavaScript hook has been removed from the view in `calendario/index.php`. The view now relies on FullCalendar's default event rendering, which correctly uses the color properties from the event source.
3.  CSS has been updated to ensure the default event title text wraps correctly within the calendar cells.

This approach resolves both the text visibility and the color-coding issues reported by the user.