### PR TITLE
fix: Change calendar event display to block

### DIFF
--- a/src/views/calendario/index.php
+++ b/src/views/calendario/index.php
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
 
     var calendar = new FullCalendar.Calendar(calendarEl, {
+        eventDisplay: 'block', // Muestra el evento como un bloque de color
         initialView: 'dayGridMonth',
         locale: 'es', // Establecer el idioma a español
         headerToolbar: {


### PR DESCRIPTION
This commit updates the 'Calendario' view to display events as solid blocks of color instead of the default dot style.

This is achieved by setting the `eventDisplay: 'block'` property in the FullCalendar configuration. This makes the events more visible and addresses the user's request for the event's background to be colored.