### PR TITLE
feat: Color calendar events by unique enrollment

### DIFF
--- a/db/THE_FINAL_UPDATE.sql
+++ b/db/THE_FINAL_UPDATE.sql
@@ -204,6 +204,7 @@ CREATE PROCEDURE `sp_get_clases_for_calendar`(
 BEGIN
     SELECT
         md.id_matricula_dia,
+        m.id_matricula,
         h.id_horario,
         c.id_curso,
         c.nombre AS curso_nombre,

--- a/src/controllers/CalendarioController.php
+++ b/src/controllers/CalendarioController.php
@@ -42,8 +42,8 @@ class CalendarioController {
             $pastel_colors = ['#a8d8ea', '#fce38a', '#eaffd0', '#f4b6c2', '#b39ddb', '#ffcc80', '#b2dfdb', '#ffAB91', '#c5e1a5'];
 
             foreach ($eventos as $evento) {
-                // Asignación de color determinista por horario
-                $event_color = $pastel_colors[$evento['id_horario'] % count($pastel_colors)];
+                // Asignación de color determinista por matrícula
+                $event_color = $pastel_colors[$evento['id_matricula'] % count($pastel_colors)];
 
                 // Crear el título directamente
                 $formatted_time = date('h:i A', strtotime($evento['hora_inicio']));


### PR DESCRIPTION
This commit enhances the 'Calendario' feature to provide more granular, user-requested color-coding for events.

- The color of each event is now determined by the unique enrollment ID (`id_matricula`) instead of the schedule ID (`id_horario`). This ensures that the same class schedule will appear as a different color if it corresponds to a different student's enrollment.
- The `sp_get_clases_for_calendar` stored procedure has been updated to provide the `id_matricula` to the controller.
- The `getEventos()` method in `CalendarioController.php` has been updated to use this new ID for its deterministic color assignment logic.