### PR TITLE
fix(calendar): Render event content with HTML for multi-line format

### DIFF
--- a/src/controllers/CalendarioController.php
+++ b/src/controllers/CalendarioController.php
@@ -45,29 +45,20 @@ class CalendarioController {
                 // Asignación de color determinista por matrícula
                 $event_color = $pastel_colors[$evento['id_matricula'] % count($pastel_colors)];
 
-                // Crear el título con el nuevo formato solicitado
-                $start_time = date('h:i A', strtotime($evento['start_datetime']));
-                $end_time = date('h:i A', strtotime($evento['end_datetime']));
-                $time_range = $start_time . ' - ' . $end_time;
-                $sub_area_info = $evento['sub_area_descripcion'] . ' - ' . $evento['sub_area_numero'];
-
-                $title = sprintf(
-                    "%s\n%s\n%s\n%s\nProf: %s\nAlum: %s",
-                    $time_range,
-                    $evento['curso_nombre'],
-                    $evento['area_nombre'],
-                    $sub_area_info,
-                    $evento['profesor_nombre'],
-                    $evento['alumno_nombre']
-                );
-
                 $calendar_events[] = [
-                    'title' => $title,
                     'start' => $evento['start_datetime'],
                     'end' => $evento['end_datetime'],
                     'backgroundColor' => $event_color,
                     'borderColor' => $event_color,
-                    'textColor' => '#333333'
+                    'textColor' => '#333333',
+                    'extendedProps' => [
+                        'curso_nombre' => $evento['curso_nombre'],
+                        'area_nombre' => $evento['area_nombre'],
+                        'sub_area_descripcion' => $evento['sub_area_descripcion'],
+                        'sub_area_numero' => $evento['sub_area_numero'],
+                        'profesor_nombre' => $evento['profesor_nombre'],
+                        'alumno_nombre' => $evento['alumno_nombre']
+                    ]
                 ];
             }
 

--- a/src/views/calendario/index.php
+++ b/src/views/calendario/index.php
@@ -40,17 +40,38 @@ document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
 
     var calendar = new FullCalendar.Calendar(calendarEl, {
-        eventDisplay: 'block', // Muestra el evento como un bloque de color
+        eventDisplay: 'block',
         initialView: 'dayGridMonth',
-        locale: 'es', // Establecer el idioma a español
+        locale: 'es',
         headerToolbar: {
             left: 'prev,next today',
             center: 'title',
             right: 'dayGridMonth,timeGridWeek,timeGridDay'
         },
-        // El backend ahora envía el 'title' y los colores directamente.
-        // FullCalendar los usará por defecto.
-        events: 'index.php?url=calendario/getEventos'
+        events: 'index.php?url=calendario/getEventos',
+        eventContent: function(arg) {
+            let props = arg.event.extendedProps;
+
+            // Formateo de la hora
+            let startTime = new Date(arg.event.start).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit', hour12: true });
+            let endTime = new Date(arg.event.end).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit', hour12: true });
+            let timeRange = startTime + ' - ' + endTime;
+
+            let subAreaInfo = props.sub_area_descripcion + ' - ' + props.sub_area_numero;
+
+            let html = `
+                <div style="font-size: 0.8em; line-height: 1.2;">
+                    ${timeRange}<br>
+                    <strong>${props.curso_nombre}</strong><br>
+                    ${props.area_nombre}<br>
+                    ${subAreaInfo}<br>
+                    Prof: ${props.profesor_nombre}<br>
+                    Alum: ${props.alumno_nombre}
+                </div>
+            `;
+
+            return { html: html };
+        }
     });
 
     calendar.render();


### PR DESCRIPTION
Refactors the calendar event rendering to correctly display multi-line text.

The backend now sends raw data via `extendedProps`. The frontend uses the `eventContent` callback to build an HTML block with `<br>` tags, ensuring the line breaks are rendered properly in the browser.