### PR TITLE
Fix: Handle enrollment date changes correctly

### DIFF
--- a/db/sp_update_matricula_dates.sql
+++ b/db/sp_update_matricula_dates.sql
@@ -1,0 +1,45 @@
+-- Stored procedure to update the dates of an enrollment
+DROP PROCEDURE IF EXISTS `sp_update_matricula_dates`;
+
+DELIMITER $$
+
+CREATE PROCEDURE `sp_update_matricula_dates`(
+    IN p_id_matricula INT,
+    IN p_new_fecha_inicio DATE,
+    IN p_new_fecha_fin DATE
+)
+BEGIN
+    DECLARE v_id_horario INT;
+    DECLARE v_dias_semana VARCHAR(50);
+
+    -- Start transaction for atomicity
+    START TRANSACTION;
+
+    -- 1. Get the current id_horario from the matricula
+    SELECT id_horario INTO v_id_horario
+    FROM matriculas
+    WHERE id_matricula = p_id_matricula;
+
+    -- 2. Get the days of the week from the existing horario
+    SELECT th.dias_semana INTO v_dias_semana
+    FROM horarios h
+    JOIN tipos_horario th ON h.id_tipo_horario = th.id_tipo_horario
+    WHERE h.id_horario = v_id_horario;
+
+    -- 3. Update the matricula with the new dates
+    UPDATE matriculas
+    SET
+        fecha_inicio = p_new_fecha_inicio,
+        fecha_fin = p_new_fecha_fin
+    WHERE id_matricula = p_id_matricula;
+
+    -- 4. Delete all old class days for this matricula
+    DELETE FROM matricula_dias WHERE id_matricula = p_id_matricula;
+
+    -- 5. Generate the new list of class days with the new configuration
+    CALL sp_generate_dias_clase(p_id_matricula, p_new_fecha_inicio, p_new_fecha_fin, v_dias_semana);
+
+    COMMIT;
+END$$
+
+DELIMITER ;

--- a/src/controllers/MatriculaController.php
+++ b/src/controllers/MatriculaController.php
@@ -167,20 +167,33 @@ class MatriculaController {
             $this->auth->verifyCsrfToken();
             $id_matricula = $_POST['id_matricula'] ?? null;
             $new_id_horario = $_POST['id_horario'] ?? null;
+            $original_id_horario = $_POST['original_id_horario'] ?? null; // Este campo se añadirá en el formulario
             $fecha_inicio = $_POST['fecha_inicio'] ?? null;
             $fecha_fin = $_POST['fecha_fin'] ?? null;
 
-            if ($id_matricula && $new_id_horario && $fecha_inicio && $fecha_fin) {
-                $db = Database::getInstance()->getConnection();
-                try {
+            if (!$id_matricula || !$new_id_horario || !$original_id_horario || !$fecha_inicio || !$fecha_fin) {
+                $_SESSION['error_message'] = "Faltan datos para actualizar la matrícula.";
+                header('Location: index.php?url=matriculas/show&id=' . $id_matricula);
+                exit;
+            }
+
+            $db = Database::getInstance()->getConnection();
+            try {
+                if ($new_id_horario != $original_id_horario) {
+                    // El horario ha cambiado, se llama al procedimiento para cambiarlo
                     $stmt = $db->prepare("CALL sp_change_horario_matricula(?, ?, ?, ?)");
                     $stmt->execute([$id_matricula, $new_id_horario, $fecha_inicio, $fecha_fin]);
-                } catch (PDOException $e) {
-                    $_SESSION['error_message'] = "Error al actualizar la matrícula: " . $e->getMessage();
+                } else {
+                    // El horario es el mismo, solo cambian las fechas. Se llama al nuevo procedimiento.
+                    $stmt = $db->prepare("CALL sp_update_matricula_dates(?, ?, ?)");
+                    $stmt->execute([$id_matricula, $fecha_inicio, $fecha_fin]);
                 }
-            } else {
-                $_SESSION['error_message'] = "Faltan datos para actualizar la matrícula.";
+                $_SESSION['success_message'] = "Matrícula actualizada correctamente.";
+
+            } catch (PDOException $e) {
+                $_SESSION['error_message'] = "Error al actualizar la matrícula: " . $e->getMessage();
             }
+
             header('Location: index.php?url=matriculas/show&id=' . $id_matricula);
             exit;
         }

--- a/src/views/matriculas/edit.php
+++ b/src/views/matriculas/edit.php
@@ -34,6 +34,7 @@ $auth = new AuthController();
     <form id="form-change-horario" action="index.php?url=matriculas/update" method="POST">
         <input type="hidden" name="csrf_token" value="<?php echo $auth->getCsrfToken(); ?>">
         <input type="hidden" name="id_matricula" value="<?php echo htmlspecialchars($matricula['id_matricula']); ?>">
+        <input type="hidden" name="original_id_horario" value="<?php echo htmlspecialchars($matricula['id_horario']); ?>">
 
         <input type="hidden" id="id_horario" name="id_horario" value="<?php echo htmlspecialchars($matricula['id_horario']); ?>" required>
 


### PR DESCRIPTION
This commit fixes a bug where updating only the dates of an enrollment would cause a foreign key constraint violation.

The issue was that the form was using a process designed for changing the entire schedule (`horario`) even when only the dates were being modified.

The fix introduces a new, dedicated stored procedure `sp_update_matricula_dates` that only updates the start and end dates of an enrollment and regenerates the attendance days.

The `MatriculaController` has been updated to differentiate between a schedule change and a date-only change. It now calls the appropriate stored procedure based on whether the `id_horario` has been modified.

The `edit.php` view has been updated to include a hidden field with the original `id_horario` to facilitate this new logic in the controller.